### PR TITLE
feat: Update to use mg5_aMC v2.8.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
         repository: scailfin/madgraph5-amc-nlo
         dockerfile: Dockerfile
-        tags: latest,mg5_amc2.7.3,mg5_amc2.7.3-python3
+        tags: latest,mg5_amc2.8.0,mg5_amc2.8.0-python3
     - name: Build and Publish to Registry with Release Tag
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v1
@@ -31,5 +31,5 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
         repository: scailfin/madgraph5-amc-nlo
         dockerfile: Dockerfile
-        tags: latest,latest-stable,mg5_amc2.7.3,mg5_amc2.7.3-python3
+        tags: latest,latest-stable,mg5_amc2.8.0,mg5_amc2.8.0-python3
         tag_with_ref: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
         repository: scailfin/madgraph5-amc-nlo
         dockerfile: Dockerfile
-        tags: latest,mg5_amc2.7.0,mg5_amc2.7.0-python3
+        tags: latest,mg5_amc2.7.3,mg5_amc2.7.3-python3
     - name: Build and Publish to Registry with Release Tag
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v1
@@ -31,5 +31,5 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
         repository: scailfin/madgraph5-amc-nlo
         dockerfile: Dockerfile
-        tags: latest,latest-stable,mg5_amc2.7.0,mg5_amc2.7.0-python3
+        tags: latest,latest-stable,mg5_amc2.7.3,mg5_amc2.7.3-python3
         tag_with_ref: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -83,7 +83,7 @@ RUN mkdir /code && \
 # Install MadGraph5_aMC@NLO for Python 3
 ARG MG_VERSION=2.8.0
 RUN cd /usr/local && \
-    wget -q https://launchpad.net/mg5amcnlo/2.0/2.7.x/+download/MG5_aMC_v${MG_VERSION}.py3.tar.gz && \
+    wget -q https://launchpad.net/mg5amcnlo/2.0/2.8.x/+download/MG5_aMC_v${MG_VERSION}.tar.gz && \
     tar xzf MG5_aMC_v${MG_VERSION}.py3.tar.gz && \
     rm MG5_aMC_v${MG_VERSION}.py3.tar.gz
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -115,7 +115,7 @@ RUN cp /root/.profile ${HOME}/.profile && \
     cp /root/.bashrc ${HOME}/.bashrc && \
     echo "" >> ${HOME}/.bashrc && \
     echo 'export PATH=${HOME}/.local/bin:$PATH' >> ${HOME}/.bashrc && \
-    echo 'export PATH=/usr/local/MG5_aMC_v2_8_0_py3/bin:$PATH' >> ${HOME}/.bashrc && \
+    echo 'export PATH=/usr/local/MG5_aMC_v2_8_0/bin:$PATH' >> ${HOME}/.bashrc && \
     python -m pip install --upgrade --no-cache-dir pip setuptools wheel && \
     python -m pip install --no-cache-dir six numpy
 
@@ -124,7 +124,7 @@ RUN cp /root/.profile ${HOME}/.profile && \
 ENV PYTHONPATH=/usr/local/lib:$PYTHONPATH
 ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 ENV PATH ${HOME}/.local/bin:$PATH
-ENV PATH /usr/local/MG5_aMC_v2_8_0_py3/bin:$PATH
+ENV PATH /usr/local/MG5_aMC_v2_8_0/bin:$PATH
 
 ENTRYPOINT ["/bin/bash", "-l", "-c"]
 CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,8 +84,8 @@ RUN mkdir /code && \
 ARG MG_VERSION=2.8.0
 RUN cd /usr/local && \
     wget -q https://launchpad.net/mg5amcnlo/2.0/2.8.x/+download/MG5_aMC_v${MG_VERSION}.tar.gz && \
-    tar xzf MG5_aMC_v${MG_VERSION}.py3.tar.gz && \
-    rm MG5_aMC_v${MG_VERSION}.py3.tar.gz
+    tar xzf MG5_aMC_v${MG_VERSION}.tar.gz && \
+    rm MG5_aMC_v${MG_VERSION}.tar.gz
 
 # Enable tab completion by uncommenting it from /etc/bash.bashrc
 # The relevant lines are those below the phrase "enable bash completion in interactive shells"

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,7 +81,7 @@ RUN mkdir /code && \
     rm -rf /code
 
 # Install MadGraph5_aMC@NLO for Python 3
-ARG MG_VERSION=2.7.3
+ARG MG_VERSION=2.8.0
 RUN cd /usr/local && \
     wget -q https://launchpad.net/mg5amcnlo/2.0/2.7.x/+download/MG5_aMC_v${MG_VERSION}.py3.tar.gz && \
     tar xzf MG5_aMC_v${MG_VERSION}.py3.tar.gz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -83,7 +83,7 @@ RUN mkdir /code && \
 # Install MadGraph5_aMC@NLO for Python 3
 ARG MG_VERSION=2.7.3
 RUN cd /usr/local && \
-    wget -q https://launchpad.net/mg5amcnlo/python3/py3.0.2/+download/MG5_aMC_v${MG_VERSION}.py3.tar.gz && \
+    wget -q https://launchpad.net/mg5amcnlo/2.0/2.7.x/+download/MG5_aMC_v${MG_VERSION}.py3.tar.gz && \
     tar xzf MG5_aMC_v${MG_VERSION}.py3.tar.gz && \
     rm MG5_aMC_v${MG_VERSION}.py3.tar.gz
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -102,7 +102,7 @@ RUN export SED_RANGE="$(($(sed -n '\|enable bash completion in interactive shell
 #    chown -R --from=root docker /usr/local
 
 ## Move files someplace
-#RUN cp -r /usr/local/MG5_aMC_v2_7_3 /home/docker/ && \
+#RUN cp -r /usr/local/MG5_aMC_v2_8_0 /home/docker/ && \
 #    chown -R --from=root docker /home/docker
 
 # Use C.UTF-8 locale to avoid issues with ASCII encoding
@@ -115,7 +115,7 @@ RUN cp /root/.profile ${HOME}/.profile && \
     cp /root/.bashrc ${HOME}/.bashrc && \
     echo "" >> ${HOME}/.bashrc && \
     echo 'export PATH=${HOME}/.local/bin:$PATH' >> ${HOME}/.bashrc && \
-    echo 'export PATH=/usr/local/MG5_aMC_v2_7_3_py3/bin:$PATH' >> ${HOME}/.bashrc && \
+    echo 'export PATH=/usr/local/MG5_aMC_v2_8_0_py3/bin:$PATH' >> ${HOME}/.bashrc && \
     python -m pip install --upgrade --no-cache-dir pip setuptools wheel && \
     python -m pip install --no-cache-dir six numpy
 
@@ -124,7 +124,7 @@ RUN cp /root/.profile ${HOME}/.profile && \
 ENV PYTHONPATH=/usr/local/lib:$PYTHONPATH
 ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 ENV PATH ${HOME}/.local/bin:$PATH
-ENV PATH /usr/local/MG5_aMC_v2_7_3_py3/bin:$PATH
+ENV PATH /usr/local/MG5_aMC_v2_8_0_py3/bin:$PATH
 
 ENTRYPOINT ["/bin/bash", "-l", "-c"]
 CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,7 +81,7 @@ RUN mkdir /code && \
     rm -rf /code
 
 # Install MadGraph5_aMC@NLO for Python 3
-ARG MG_VERSION=2.7.0
+ARG MG_VERSION=2.7.3
 RUN cd /usr/local && \
     wget -q https://launchpad.net/mg5amcnlo/python3/py3.0.2/+download/MG5_aMC_v${MG_VERSION}.py3.tar.gz && \
     tar xzf MG5_aMC_v${MG_VERSION}.py3.tar.gz && \
@@ -102,7 +102,7 @@ RUN export SED_RANGE="$(($(sed -n '\|enable bash completion in interactive shell
 #    chown -R --from=root docker /usr/local
 
 ## Move files someplace
-#RUN cp -r /usr/local/MG5_aMC_v2_7_2 /home/docker/ && \
+#RUN cp -r /usr/local/MG5_aMC_v2_7_3 /home/docker/ && \
 #    chown -R --from=root docker /home/docker
 
 # Use C.UTF-8 locale to avoid issues with ASCII encoding
@@ -115,7 +115,7 @@ RUN cp /root/.profile ${HOME}/.profile && \
     cp /root/.bashrc ${HOME}/.bashrc && \
     echo "" >> ${HOME}/.bashrc && \
     echo 'export PATH=${HOME}/.local/bin:$PATH' >> ${HOME}/.bashrc && \
-    echo 'export PATH=/usr/local/MG5_aMC_v2_7_0_py3/bin:$PATH' >> ${HOME}/.bashrc && \
+    echo 'export PATH=/usr/local/MG5_aMC_v2_7_3_py3/bin:$PATH' >> ${HOME}/.bashrc && \
     python -m pip install --upgrade --no-cache-dir pip setuptools wheel && \
     python -m pip install --no-cache-dir six numpy
 
@@ -124,7 +124,7 @@ RUN cp /root/.profile ${HOME}/.profile && \
 ENV PYTHONPATH=/usr/local/lib:$PYTHONPATH
 ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 ENV PATH ${HOME}/.local/bin:$PATH
-ENV PATH /usr/local/MG5_aMC_v2_7_0_py3/bin:$PATH
+ENV PATH /usr/local/MG5_aMC_v2_7_3_py3/bin:$PATH
 
 ENTRYPOINT ["/bin/bash", "-l", "-c"]
 CMD ["/bin/bash"]

--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,10 @@ image:
 	--build-arg FASTJET_VERSION=3.3.4 \
 	--build-arg LHAPDF_VERSION=6.3.0 \
 	--build-arg PYTHIA_VERSION=8302 \
-	--build-arg MG_VERSION=2.7.3 \
+	--build-arg MG_VERSION=2.8.0 \
 	-t scailfin/madgraph5-amc-nlo:latest \
-	-t scailfin/madgraph5-amc-nlo:2.7.3 \
-	-t scailfin/madgraph5-amc-nlo:2.7.3-python3 \
+	-t scailfin/madgraph5-amc-nlo:2.8.0 \
+	-t scailfin/madgraph5-amc-nlo:2.8.0-python3 \
 	--compress
 
 test:
@@ -22,5 +22,5 @@ test:
 	--build-arg FASTJET_VERSION=3.3.4 \
 	--build-arg LHAPDF_VERSION=6.3.0 \
 	--build-arg PYTHIA_VERSION=8302 \
-	--build-arg MG_VERSION=2.7.3 \
+	--build-arg MG_VERSION=2.8.0 \
 	-t scailfin/madgraph5-amc-nlo:debug-local

--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,10 @@ image:
 	--build-arg FASTJET_VERSION=3.3.4 \
 	--build-arg LHAPDF_VERSION=6.3.0 \
 	--build-arg PYTHIA_VERSION=8302 \
-	--build-arg MG_VERSION=2.7.0 \
+	--build-arg MG_VERSION=2.7.3 \
 	-t scailfin/madgraph5-amc-nlo:latest \
-	-t scailfin/madgraph5-amc-nlo:2.7.0 \
-	-t scailfin/madgraph5-amc-nlo:2.7.0-python3 \
+	-t scailfin/madgraph5-amc-nlo:2.7.3 \
+	-t scailfin/madgraph5-amc-nlo:2.7.3-python3 \
 	--compress
 
 test:
@@ -22,5 +22,5 @@ test:
 	--build-arg FASTJET_VERSION=3.3.4 \
 	--build-arg LHAPDF_VERSION=6.3.0 \
 	--build-arg PYTHIA_VERSION=8302 \
-	--build-arg MG_VERSION=2.7.0 \
+	--build-arg MG_VERSION=2.7.3 \
 	-t scailfin/madgraph5-amc-nlo:debug-local

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Docker image for Python 3 compliant [MadGraph5_aMC@NLO](https://launchpad.net/mg
 
 The Docker image contains:
 
-* [MadGraph5_aMC@NLO](https://launchpad.net/mg5amcnlo) `v2.7.3`
+* [MadGraph5_aMC@NLO](https://launchpad.net/mg5amcnlo) `v2.8.0`
 * Python 3.8
 * [FastJet](http://fastjet.fr/) `v3.3.4`
 * [LHAPDF](https://lhapdf.hepforge.org/) `v6.3.0`
@@ -22,7 +22,7 @@ The Docker image contains:
 - Use `docker pull` to pull down the image corresponding to the tag. For example:
 
 ```
-docker pull scailfin/madgraph5-amc-nlo:mg5_amc2.7.3-python3
+docker pull scailfin/madgraph5-amc-nlo:mg5_amc2.8.0-python3
 ```
 
 ## Tests
@@ -30,5 +30,5 @@ docker pull scailfin/madgraph5-amc-nlo:mg5_amc2.7.3-python3
 As an example test you can run the [top mass scan example](https://answers.launchpad.net/mg5amcnlo/+faq/2186) in the `tests` directory inside the Docker container by running the following from the top level directory of this repository
 
 ```
-docker run --rm -v $PWD:$PWD -w $PWD scailfin/madgraph5-amc-nlo:mg5_amc2.7.3-python3 "mg5_aMC tests/test_top_mass_scan.txt"
+docker run --rm -v $PWD:$PWD -w $PWD scailfin/madgraph5-amc-nlo:mg5_amc2.8.0-python3 "mg5_aMC tests/test_top_mass_scan.txt"
 ```

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Docker image for Python 3 compliant [MadGraph5_aMC@NLO](https://launchpad.net/mg
 
 The Docker image contains:
 
-* [MadGraph5_aMC@NLO](https://launchpad.net/mg5amcnlo) `v2.7.0`
+* [MadGraph5_aMC@NLO](https://launchpad.net/mg5amcnlo) `v2.7.3`
 * Python 3.8
 * [FastJet](http://fastjet.fr/) `v3.3.4`
 * [LHAPDF](https://lhapdf.hepforge.org/) `v6.3.0`
@@ -22,7 +22,7 @@ The Docker image contains:
 - Use `docker pull` to pull down the image corresponding to the tag. For example:
 
 ```
-docker pull scailfin/madgraph5-amc-nlo:mg5_amc2.7.0-python3
+docker pull scailfin/madgraph5-amc-nlo:mg5_amc2.7.3-python3
 ```
 
 ## Tests
@@ -30,5 +30,5 @@ docker pull scailfin/madgraph5-amc-nlo:mg5_amc2.7.0-python3
 As an example test you can run the [top mass scan example](https://answers.launchpad.net/mg5amcnlo/+faq/2186) in the `tests` directory inside the Docker container by running the following from the top level directory of this repository
 
 ```
-docker run --rm -v $PWD:$PWD -w $PWD scailfin/madgraph5-amc-nlo:mg5_amc2.7.0-python3 "mg5_aMC tests/test_top_mass_scan.txt"
+docker run --rm -v $PWD:$PWD -w $PWD scailfin/madgraph5-amc-nlo:mg5_amc2.7.3-python3 "mg5_aMC tests/test_top_mass_scan.txt"
 ```


### PR DESCRIPTION
Update to release [`v2.8.0` of MadGraph5_aMC-NLO](https://launchpad.net/mg5amcnlo/2.0/2.8.x)

```
* Update to MadGraph5_aMC-NLO v2.8.0
   - c.f. https://launchpad.net/mg5amcnlo/2.0/2.8.x/+download/MG5_aMC_v2.8.0.tar.gz
```