### PR TITLE
chore: Migrate namespace to SCAILFIN

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       if: "!(startsWith(github.ref, 'refs/tags/'))"
       uses: docker/build-push-action@v1
       with:
-        repository: matthewfeickert/madgraph5-amc-nlo
+        repository: scailfin/madgraph5-amc-nlo
         dockerfile: Dockerfile
         tags: test
         tag_with_sha: true
@@ -30,5 +30,5 @@ jobs:
         docker run --rm
         -v $PWD:$PWD
         -w $PWD
-        matthewfeickert/madgraph5-amc-nlo:test
+        scailfin/madgraph5-amc-nlo:test
         "mg5_aMC tests/test_top_mass_scan.txt"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-        repository: matthewfeickert/madgraph5-amc-nlo
+        repository: scailfin/madgraph5-amc-nlo
         dockerfile: Dockerfile
         tags: latest,mg5_amc2.7.0,mg5_amc2.7.0-python3
     - name: Build and Publish to Registry with Release Tag
@@ -29,7 +29,7 @@ jobs:
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-        repository: matthewfeickert/madgraph5-amc-nlo
+        repository: scailfin/madgraph5-amc-nlo
         dockerfile: Dockerfile
         tags: latest,latest-stable,mg5_amc2.7.0,mg5_amc2.7.0-python3
         tag_with_ref: true

--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,9 @@ image:
 	--build-arg LHAPDF_VERSION=6.3.0 \
 	--build-arg PYTHIA_VERSION=8302 \
 	--build-arg MG_VERSION=2.7.0 \
-	-t matthewfeickert/madgraph5-amc-nlo:latest \
-	-t matthewfeickert/madgraph5-amc-nlo:2.7.0 \
-	-t matthewfeickert/madgraph5-amc-nlo:2.7.0-python3 \
+	-t scailfin/madgraph5-amc-nlo:latest \
+	-t scailfin/madgraph5-amc-nlo:2.7.0 \
+	-t scailfin/madgraph5-amc-nlo:2.7.0-python3 \
 	--compress
 
 test:
@@ -23,4 +23,4 @@ test:
 	--build-arg LHAPDF_VERSION=6.3.0 \
 	--build-arg PYTHIA_VERSION=8302 \
 	--build-arg MG_VERSION=2.7.0 \
-	-t matthewfeickert/madgraph5-amc-nlo:debug-local
+	-t scailfin/madgraph5-amc-nlo:debug-local

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 Docker image for Python 3 compliant [MadGraph5_aMC@NLO](https://launchpad.net/mg5amcnlo).
 
-[![GitHub Actions Status: CI](https://github.com/matthewfeickert/MadGraph5_aMC-NLO/workflows/CI/badge.svg?branch=master)](https://github.com/matthewfeickert/MadGraph5_aMC-NLO/actions?query=workflow%3ACI+branch%3Amaster)
-[![Docker Pulls](https://img.shields.io/docker/pulls/matthewfeickert/madgraph5-amc-nlo)](https://hub.docker.com/r/matthewfeickert/madgraph5-amc-nlo)
-[![Docker Image Size (tag)](https://img.shields.io/docker/image-size/matthewfeickert/madgraph5-amc-nlo/latest)](https://hub.docker.com/r/matthewfeickert/madgraph5-amc-nlo/tags?name=latest)
+[![GitHub Actions Status: CI](https://github.com/scailfin/MadGraph5_aMC-NLO/workflows/CI/badge.svg?branch=master)](https://github.com/scailfin/MadGraph5_aMC-NLO/actions?query=workflow%3ACI+branch%3Amaster)
+[![Docker Pulls](https://img.shields.io/docker/pulls/scailfin/madgraph5-amc-nlo)](https://hub.docker.com/r/scailfin/madgraph5-amc-nlo)
+[![Docker Image Size (tag)](https://img.shields.io/docker/image-size/scailfin/madgraph5-amc-nlo/latest)](https://hub.docker.com/r/scailfin/madgraph5-amc-nlo/tags?name=latest)
 
 ## Distributed Software
 
@@ -18,11 +18,11 @@ The Docker image contains:
 
 ## Installation
 
-- Check the [list of available tags on Docker Hub](https://hub.docker.com/r/matthewfeickert/madgraph5-amc-nlo/tags?page=1) to find the tag you want.
+- Check the [list of available tags on Docker Hub](https://hub.docker.com/r/scailfin/madgraph5-amc-nlo/tags?page=1) to find the tag you want.
 - Use `docker pull` to pull down the image corresponding to the tag. For example:
 
 ```
-docker pull matthewfeickert/madgraph5-amc-nlo:mg5_amc2.7.0-python3
+docker pull scailfin/madgraph5-amc-nlo:mg5_amc2.7.0-python3
 ```
 
 ## Tests
@@ -30,5 +30,5 @@ docker pull matthewfeickert/madgraph5-amc-nlo:mg5_amc2.7.0-python3
 As an example test you can run the [top mass scan example](https://answers.launchpad.net/mg5amcnlo/+faq/2186) in the `tests` directory inside the Docker container by running the following from the top level directory of this repository
 
 ```
-docker run --rm -v $PWD:$PWD -w $PWD matthewfeickert/madgraph5-amc-nlo:mg5_amc2.7.0-python3 "mg5_aMC tests/test_top_mass_scan.txt"
+docker run --rm -v $PWD:$PWD -w $PWD scailfin/madgraph5-amc-nlo:mg5_amc2.7.0-python3 "mg5_aMC tests/test_top_mass_scan.txt"
 ```


### PR DESCRIPTION
Migrate the namespace associated with the Docker image from https://github.com/matthewfeickert/MadGraph5_aMC-NLO to SCAILFIN.

```
* Update namespace and URLs from matthewfeickert to scailfin
```