### PR TITLE
feat: Update to PYTHIA v8.303

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,7 +81,7 @@ RUN mkdir /code && \
     rm -rf /code
 
 # Install PYTHIA
-ARG PYTHIA_VERSION=8302
+ARG PYTHIA_VERSION=8303
 # PYTHON_VERSION already exists in the base image
 RUN mkdir /code && \
     cd /code && \

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ image:
 	--build-arg HEPMC_VERSION=2.06.11 \
 	--build-arg FASTJET_VERSION=3.3.4 \
 	--build-arg LHAPDF_VERSION=6.3.0 \
-	--build-arg PYTHIA_VERSION=8302 \
+	--build-arg PYTHIA_VERSION=8303 \
 	--build-arg MG_VERSION=2.8.1 \
 	-t scailfin/madgraph5-amc-nlo:latest \
 	-t scailfin/madgraph5-amc-nlo:2.8.1 \
@@ -23,6 +23,6 @@ test:
 	--build-arg HEPMC_VERSION=2.06.11 \
 	--build-arg FASTJET_VERSION=3.3.4 \
 	--build-arg LHAPDF_VERSION=6.3.0 \
-	--build-arg PYTHIA_VERSION=8302 \
+	--build-arg PYTHIA_VERSION=8303 \
 	--build-arg MG_VERSION=2.8.1 \
 	-t scailfin/madgraph5-amc-nlo:debug-local

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The Docker image contains:
 * [HepMC2](http://hepmc.web.cern.ch/hepmc/) `v2.06.11`
 * [LHAPDF](https://lhapdf.hepforge.org/) `v6.3.0`
 * [FastJet](http://fastjet.fr/) `v3.3.4`
-* [PYTHIA](http://home.thep.lu.se/~torbjorn/Pythia.html) `v8.302`
+* [PYTHIA](http://home.thep.lu.se/~torbjorn/Pythia.html) `v8.303`
 
 ## Installation
 


### PR DESCRIPTION
Update PYTHIA to v8.303

```
* Update to PYTHIA v8.303
   - c.f. http://home.thep.lu.se/~torbjorn/pythia8/pythia8303.tgz
```