### PR TITLE
feat: Set dependency options in MadGraph config settings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -114,6 +114,7 @@ RUN cd /usr/local && \
 
 # Change the MadGraph5_aMC@NLO configuration settings
 RUN sed -i '/fastjet =/s/^# //g' /usr/local/MG5_aMC_v2_8_1/input/mg5_configuration.txt &&
+    sed -i '/lhapdf_py3 =/s/^# //g' /usr/local/MG5_aMC_v2_8_1/input/mg5_configuration.txt
 
 # Enable tab completion by uncommenting it from /etc/bash.bashrc
 # The relevant lines are those below the phrase "enable bash completion in interactive shells"

--- a/Dockerfile
+++ b/Dockerfile
@@ -112,6 +112,9 @@ RUN cd /usr/local && \
     tar xzf MG5_aMC_v${MG_VERSION}.tar.gz && \
     rm MG5_aMC_v${MG_VERSION}.tar.gz
 
+# Change the MadGraph5_aMC@NLO configuration settings
+RUN sed -i '/fastjet =/s/^# //g' /usr/local/MG5_aMC_v2_8_1/input/mg5_configuration.txt &&
+
 # Enable tab completion by uncommenting it from /etc/bash.bashrc
 # The relevant lines are those below the phrase "enable bash completion in interactive shells"
 RUN export SED_RANGE="$(($(sed -n '\|enable bash completion in interactive shells|=' /etc/bash.bashrc)+1)),$(($(sed -n '\|enable bash completion in interactive shells|=' /etc/bash.bashrc)+7))" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -113,8 +113,8 @@ RUN cd /usr/local && \
     rm MG5_aMC_v${MG_VERSION}.tar.gz
 
 # Change the MadGraph5_aMC@NLO configuration settings
-RUN sed -i '/fastjet =/s/^# //g' /usr/local/MG5_aMC_v2_8_1/input/mg5_configuration.txt &&
-    sed -i '/lhapdf_py3 =/s/^# //g' /usr/local/MG5_aMC_v2_8_1/input/mg5_configuration.txt &&
+RUN sed -i '/fastjet =/s/^# //g' /usr/local/MG5_aMC_v2_8_1/input/mg5_configuration.txt && \
+    sed -i '/lhapdf_py3 =/s/^# //g' /usr/local/MG5_aMC_v2_8_1/input/mg5_configuration.txt && \
     sed -i 's|# pythia8_path.*|pythia8_path = /usr/local|g' /usr/local/MG5_aMC_v2_8_1/input/mg5_configuration.txt
 
 # Enable tab completion by uncommenting it from /etc/bash.bashrc

--- a/Dockerfile
+++ b/Dockerfile
@@ -114,7 +114,8 @@ RUN cd /usr/local && \
 
 # Change the MadGraph5_aMC@NLO configuration settings
 RUN sed -i '/fastjet =/s/^# //g' /usr/local/MG5_aMC_v2_8_1/input/mg5_configuration.txt &&
-    sed -i '/lhapdf_py3 =/s/^# //g' /usr/local/MG5_aMC_v2_8_1/input/mg5_configuration.txt
+    sed -i '/lhapdf_py3 =/s/^# //g' /usr/local/MG5_aMC_v2_8_1/input/mg5_configuration.txt &&
+    sed -i 's|# pythia8_path.*|pythia8_path = /usr/local|g' /usr/local/MG5_aMC_v2_8_1/input/mg5_configuration.txt
 
 # Enable tab completion by uncommenting it from /etc/bash.bashrc
 # The relevant lines are those below the phrase "enable bash completion in interactive shells"


### PR DESCRIPTION
Set the dependency paths in the MadGraph configuration settings in `/usr/local/MG5_aMC_v2_8_1/input/mg5_configuration.txt`

```
* Set dependency configurations in MadGraph configuration settings
   - Set fastjet, lhapdf_py3, pythia8_path
```