### PR TITLE
fix: Correct Python external paths for PYTHIA

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -100,7 +100,7 @@ RUN mkdir /code && \
       --with-fastjet3 \
       --with-python-bin=/usr/local/bin \
       --with-python-lib=/usr/local/lib/python${PYTHON_MINOR_VERSION} \
-      --with-python-include=/usr/include/python${PYTHON_MINOR_VERSION} && \
+      --with-python-include=/usr/local/include/python${PYTHON_MINOR_VERSION} && \
     make -j$(($(nproc) - 1)) && \
     make install && \
     rm -rf /code

--- a/Dockerfile
+++ b/Dockerfile
@@ -99,7 +99,7 @@ RUN mkdir /code && \
       --with-lhapdf6 \
       --with-fastjet3 \
       --with-python-bin=/usr/local/bin \
-      --with-python-lib=/usr/lib/python${PYTHON_MINOR_VERSION} \
+      --with-python-lib=/usr/local/lib/python${PYTHON_MINOR_VERSION} \
       --with-python-include=/usr/include/python${PYTHON_MINOR_VERSION} && \
     make -j$(($(nproc) - 1)) && \
     make install && \


### PR DESCRIPTION
```
* Set Python external paths for PYTHIA to use /usr/local/
   - Fix --with-python-lib and --with-python-include
```