### PR TITLE
feat: Add MG5aMC to PYTHIA 8 interface

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -105,14 +105,14 @@ RUN mkdir /code && \
     make install && \
     rm -rf /code
 
-# Install MadGraph5_aMC@NLO for Python 3
+# Install MadGraph5_aMC@NLO for Python 3 and PYTHIA 8 interface
 ARG MG_VERSION=2.8.1
 RUN cd /usr/local && \
     wget --quiet https://launchpad.net/mg5amcnlo/2.0/2.8.x/+download/MG5_aMC_v${MG_VERSION}.tar.gz && \
     tar xzf MG5_aMC_v${MG_VERSION}.tar.gz && \
-    rm MG5_aMC_v${MG_VERSION}.tar.gz
-
-RUN mkdir /code && \
+    rm MG5_aMC_v${MG_VERSION}.tar.gz && \
+    echo "Installing MG5aMC_PY8_interface" && \
+    mkdir /code && \
     cd /code && \
     wget --quiet http://madgraph.phys.ucl.ac.be/Downloads/MG5aMC_PY8_interface/MG5aMC_PY8_interface_V1.0.tar.gz && \
     mkdir -p /code/MG5aMC_PY8_interface && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,7 +81,7 @@ RUN mkdir /code && \
     rm -rf /code
 
 # Install PYTHIA
-ARG PYTHIA_VERSION=8303
+ARG PYTHIA_VERSION=8243
 # PYTHON_VERSION already exists in the base image
 RUN mkdir /code && \
     cd /code && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -85,7 +85,7 @@ ARG PYTHIA_VERSION=8243
 # PYTHON_VERSION already exists in the base image
 RUN mkdir /code && \
     cd /code && \
-    wget http://home.thep.lu.se/~torbjorn/pythia8/pythia${PYTHIA_VERSION}.tgz && \
+    wget --quiet http://home.thep.lu.se/~torbjorn/pythia8/pythia${PYTHIA_VERSION}.tgz && \
     tar xvfz pythia${PYTHIA_VERSION}.tgz && \
     cd pythia${PYTHIA_VERSION} && \
     ./configure --help && \
@@ -108,13 +108,13 @@ RUN mkdir /code && \
 # Install MadGraph5_aMC@NLO for Python 3
 ARG MG_VERSION=2.8.1
 RUN cd /usr/local && \
-    wget -q https://launchpad.net/mg5amcnlo/2.0/2.8.x/+download/MG5_aMC_v${MG_VERSION}.tar.gz && \
+    wget --quiet https://launchpad.net/mg5amcnlo/2.0/2.8.x/+download/MG5_aMC_v${MG_VERSION}.tar.gz && \
     tar xzf MG5_aMC_v${MG_VERSION}.tar.gz && \
     rm MG5_aMC_v${MG_VERSION}.tar.gz
 
 RUN mkdir /code && \
     cd /code && \
-    wget -q http://madgraph.phys.ucl.ac.be/Downloads/MG5aMC_PY8_interface/MG5aMC_PY8_interface_V1.0.tar.gz && \
+    wget --quiet http://madgraph.phys.ucl.ac.be/Downloads/MG5aMC_PY8_interface/MG5aMC_PY8_interface_V1.0.tar.gz && \
     mkdir -p /code/MG5aMC_PY8_interface && \
     tar -xf MG5aMC_PY8_interface_V1.0.tar.gz -C MG5aMC_PY8_interface && \
     cd MG5aMC_PY8_interface && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -98,7 +98,7 @@ RUN mkdir /code && \
       --with-hepmc2 \
       --with-lhapdf6 \
       --with-fastjet3 \
-      --with-python-bin=/usr/local/bin \
+      --with-python-bin=/usr/local/bin/ \
       --with-python-lib=/usr/local/lib/python${PYTHON_MINOR_VERSION} \
       --with-python-include=/usr/local/include/python${PYTHON_MINOR_VERSION} && \
     make -j$(($(nproc) - 1)) && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -112,10 +112,24 @@ RUN cd /usr/local && \
     tar xzf MG5_aMC_v${MG_VERSION}.tar.gz && \
     rm MG5_aMC_v${MG_VERSION}.tar.gz
 
+RUN mkdir /code && \
+    cd /code && \
+    wget -q http://madgraph.phys.ucl.ac.be/Downloads/MG5aMC_PY8_interface/MG5aMC_PY8_interface_V1.0.tar.gz && \
+    mkdir -p /code/MG5aMC_PY8_interface && \
+    tar -xf MG5aMC_PY8_interface_V1.0.tar.gz -C MG5aMC_PY8_interface && \
+    cd MG5aMC_PY8_interface && \
+    python compile.py /usr/local/ --pythia8_makefile && \
+    mkdir -p /usr/local/MG5_aMC_v2_8_1/HEPTools/MG5aMC_PY8_interface && \
+    cp *.h /usr/local/MG5_aMC_v2_8_1/HEPTools/MG5aMC_PY8_interface/ && \
+    cp *_VERSION_ON_INSTALL /usr/local/MG5_aMC_v2_8_1/HEPTools/MG5aMC_PY8_interface/ && \
+    cp MG5aMC_PY8_interface /usr/local/MG5_aMC_v2_8_1/HEPTools/MG5aMC_PY8_interface/ && \
+    rm -rf /code
+
 # Change the MadGraph5_aMC@NLO configuration settings
 RUN sed -i '/fastjet =/s/^# //g' /usr/local/MG5_aMC_v2_8_1/input/mg5_configuration.txt && \
     sed -i '/lhapdf_py3 =/s/^# //g' /usr/local/MG5_aMC_v2_8_1/input/mg5_configuration.txt && \
-    sed -i 's|# pythia8_path.*|pythia8_path = /usr/local|g' /usr/local/MG5_aMC_v2_8_1/input/mg5_configuration.txt
+    sed -i 's|# pythia8_path.*|pythia8_path = /usr/local|g' /usr/local/MG5_aMC_v2_8_1/input/mg5_configuration.txt && \
+    sed -i '/mg5amc_py8_interface_path =/s/^# //g' /usr/local/MG5_aMC_v2_8_1/input/mg5_configuration.txt
 
 # Enable tab completion by uncommenting it from /etc/bash.bashrc
 # The relevant lines are those below the phrase "enable bash completion in interactive shells"

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ image:
 	--build-arg HEPMC_VERSION=2.06.11 \
 	--build-arg FASTJET_VERSION=3.3.4 \
 	--build-arg LHAPDF_VERSION=6.3.0 \
-	--build-arg PYTHIA_VERSION=8303 \
+	--build-arg PYTHIA_VERSION=8243 \
 	--build-arg MG_VERSION=2.8.1 \
 	-t scailfin/madgraph5-amc-nlo:latest \
 	-t scailfin/madgraph5-amc-nlo:2.8.1 \
@@ -23,6 +23,6 @@ test:
 	--build-arg HEPMC_VERSION=2.06.11 \
 	--build-arg FASTJET_VERSION=3.3.4 \
 	--build-arg LHAPDF_VERSION=6.3.0 \
-	--build-arg PYTHIA_VERSION=8303 \
+	--build-arg PYTHIA_VERSION=8243 \
 	--build-arg MG_VERSION=2.8.1 \
 	-t scailfin/madgraph5-amc-nlo:debug-local

--- a/README.md
+++ b/README.md
@@ -31,5 +31,5 @@ docker pull scailfin/madgraph5-amc-nlo:mg5_amc2.8.1-python3
 As an example test you can run the [top mass scan example](https://answers.launchpad.net/mg5amcnlo/+faq/2186) in the `tests` directory inside the Docker container by running the following from the top level directory of this repository
 
 ```
-docker run --rm -v $PWD:$PWD -w $PWD scailfin/madgraph5-amc-nlo:mg5_amc2.8.1-python3 "mg5_aMC tests/test_top_mass_scan.txt"
+docker run --rm -v $PWD:$PWD -w $PWD scailfin/madgraph5-amc-nlo:mg5_amc2.8.1-python3 "lhapdf install NNPDF23_lo_as_0130_qed; mg5_aMC tests/test_top_mass_scan.txt"
 ```

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The Docker image contains:
 * [HepMC2](http://hepmc.web.cern.ch/hepmc/) `v2.06.11`
 * [LHAPDF](https://lhapdf.hepforge.org/) `v6.3.0`
 * [FastJet](http://fastjet.fr/) `v3.3.4`
-* [PYTHIA](http://home.thep.lu.se/~torbjorn/Pythia.html) `v8.303`
+* [PYTHIA](http://home.thep.lu.se/~torbjorn/Pythia.html) `v8.243`
 
 ## Installation
 


### PR DESCRIPTION
From the discussion in [MadGraph5_aMC@NLO question 693533](https://answers.launchpad.net/mg5amcnlo/+question/693533), MadGraph5 does not support PYTHIA `8.3XX`, so to have the `MG5aMC_PY8_interface` work PYTHIA 8 must be downgraded to `v8.243`.

```
* Add support for MG5aMC_PY8_interface
   - Requires downgrading PYTHIA 8 to v8.2XX series
   - c.f. https://answers.launchpad.net/mg5amcnlo/+question/693533
* Use PYTHIA v8.243
* Use wget --quiet flag to suppress download information stream 
```