### PR TITLE
feat: Update to mg5_aMC v2.8.2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
         repository: scailfin/madgraph5-amc-nlo
         dockerfile: Dockerfile
-        tags: latest,mg5_amc2.8.1,mg5_amc2.8.1-python3
+        tags: latest,mg5_amc2.8.2,mg5_amc2.8.2-python3
     - name: Build and Publish to Registry with Release Tag
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v1
@@ -31,5 +31,5 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
         repository: scailfin/madgraph5-amc-nlo
         dockerfile: Dockerfile
-        tags: latest,latest-stable,mg5_amc2.8.1,mg5_amc2.8.1-python3
+        tags: latest,latest-stable,mg5_amc2.8.2,mg5_amc2.8.2-python3
         tag_with_ref: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -107,7 +107,7 @@ RUN mkdir /code && \
     rm -rf /code
 
 # Install MadGraph5_aMC@NLO for Python 3 and PYTHIA 8 interface
-ARG MG_VERSION=2.8.1
+ARG MG_VERSION=2.8.2
 RUN cd /usr/local && \
     wget --quiet https://launchpad.net/mg5amcnlo/2.0/2.8.x/+download/MG5_aMC_v${MG_VERSION}.tar.gz && \
     tar xzf MG5_aMC_v${MG_VERSION}.tar.gz && \
@@ -120,17 +120,17 @@ RUN cd /usr/local && \
     tar -xf MG5aMC_PY8_interface_V1.0.tar.gz -C MG5aMC_PY8_interface && \
     cd MG5aMC_PY8_interface && \
     python compile.py /usr/local/ --pythia8_makefile && \
-    mkdir -p /usr/local/MG5_aMC_v2_8_1/HEPTools/MG5aMC_PY8_interface && \
-    cp *.h /usr/local/MG5_aMC_v2_8_1/HEPTools/MG5aMC_PY8_interface/ && \
-    cp *_VERSION_ON_INSTALL /usr/local/MG5_aMC_v2_8_1/HEPTools/MG5aMC_PY8_interface/ && \
-    cp MG5aMC_PY8_interface /usr/local/MG5_aMC_v2_8_1/HEPTools/MG5aMC_PY8_interface/ && \
+    mkdir -p /usr/local/MG5_aMC_v2_8_2/HEPTools/MG5aMC_PY8_interface && \
+    cp *.h /usr/local/MG5_aMC_v2_8_2/HEPTools/MG5aMC_PY8_interface/ && \
+    cp *_VERSION_ON_INSTALL /usr/local/MG5_aMC_v2_8_2/HEPTools/MG5aMC_PY8_interface/ && \
+    cp MG5aMC_PY8_interface /usr/local/MG5_aMC_v2_8_2/HEPTools/MG5aMC_PY8_interface/ && \
     rm -rf /code
 
 # Change the MadGraph5_aMC@NLO configuration settings
-RUN sed -i '/fastjet =/s/^# //g' /usr/local/MG5_aMC_v2_8_1/input/mg5_configuration.txt && \
-    sed -i '/lhapdf_py3 =/s/^# //g' /usr/local/MG5_aMC_v2_8_1/input/mg5_configuration.txt && \
-    sed -i 's|# pythia8_path.*|pythia8_path = /usr/local|g' /usr/local/MG5_aMC_v2_8_1/input/mg5_configuration.txt && \
-    sed -i '/mg5amc_py8_interface_path =/s/^# //g' /usr/local/MG5_aMC_v2_8_1/input/mg5_configuration.txt
+RUN sed -i '/fastjet =/s/^# //g' /usr/local/MG5_aMC_v2_8_2/input/mg5_configuration.txt && \
+    sed -i '/lhapdf_py3 =/s/^# //g' /usr/local/MG5_aMC_v2_8_2/input/mg5_configuration.txt && \
+    sed -i 's|# pythia8_path.*|pythia8_path = /usr/local|g' /usr/local/MG5_aMC_v2_8_2/input/mg5_configuration.txt && \
+    sed -i '/mg5amc_py8_interface_path =/s/^# //g' /usr/local/MG5_aMC_v2_8_2/input/mg5_configuration.txt
 
 # Enable tab completion by uncommenting it from /etc/bash.bashrc
 # The relevant lines are those below the phrase "enable bash completion in interactive shells"
@@ -147,7 +147,7 @@ RUN export SED_RANGE="$(($(sed -n '\|enable bash completion in interactive shell
 #    chown -R --from=root docker /usr/local
 
 ## Move files someplace
-#RUN cp -r /usr/local/MG5_aMC_v2_8_1 /home/docker/ && \
+#RUN cp -r /usr/local/MG5_aMC_v2_8_2 /home/docker/ && \
 #    chown -R --from=root docker /home/docker
 
 # Use C.UTF-8 locale to avoid issues with ASCII encoding
@@ -160,16 +160,16 @@ RUN cp /root/.profile ${HOME}/.profile && \
     cp /root/.bashrc ${HOME}/.bashrc && \
     echo "" >> ${HOME}/.bashrc && \
     echo 'export PATH=${HOME}/.local/bin:$PATH' >> ${HOME}/.bashrc && \
-    echo 'export PATH=/usr/local/MG5_aMC_v2_8_1/bin:$PATH' >> ${HOME}/.bashrc && \
+    echo 'export PATH=/usr/local/MG5_aMC_v2_8_2/bin:$PATH' >> ${HOME}/.bashrc && \
     python -m pip install --upgrade --no-cache-dir pip setuptools wheel && \
     python -m pip install --no-cache-dir six numpy
 
 #ENV USER docker
 #USER docker
-ENV PYTHONPATH=/usr/local/lib:/usr/local/MG5_aMC_v2_8_1:$PYTHONPATH
+ENV PYTHONPATH=/usr/local/lib:/usr/local/MG5_aMC_v2_8_2:$PYTHONPATH
 ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 ENV PATH ${HOME}/.local/bin:$PATH
-ENV PATH /usr/local/MG5_aMC_v2_8_1/bin:$PATH
+ENV PATH /usr/local/MG5_aMC_v2_8_2/bin:$PATH
 
 ENTRYPOINT ["/bin/bash", "-l", "-c"]
 CMD ["/bin/bash"]

--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,10 @@ image:
 	--build-arg FASTJET_VERSION=3.3.4 \
 	--build-arg LHAPDF_VERSION=6.3.0 \
 	--build-arg PYTHIA_VERSION=8243 \
-	--build-arg MG_VERSION=2.8.1 \
+	--build-arg MG_VERSION=2.8.2 \
 	-t scailfin/madgraph5-amc-nlo:latest \
-	-t scailfin/madgraph5-amc-nlo:2.8.1 \
-	-t scailfin/madgraph5-amc-nlo:2.8.1-python3 \
+	-t scailfin/madgraph5-amc-nlo:2.8.2 \
+	-t scailfin/madgraph5-amc-nlo:2.8.2-python3 \
 	--compress
 
 test:
@@ -24,5 +24,5 @@ test:
 	--build-arg FASTJET_VERSION=3.3.4 \
 	--build-arg LHAPDF_VERSION=6.3.0 \
 	--build-arg PYTHIA_VERSION=8243 \
-	--build-arg MG_VERSION=2.8.1 \
+	--build-arg MG_VERSION=2.8.2 \
 	-t scailfin/madgraph5-amc-nlo:debug-local

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Docker image for Python 3 compliant [MadGraph5_aMC@NLO](https://launchpad.net/mg
 
 The Docker image contains:
 
-* [MadGraph5_aMC@NLO](https://launchpad.net/mg5amcnlo) `v2.8.1`
+* [MadGraph5_aMC@NLO](https://launchpad.net/mg5amcnlo) `v2.8.2`
 * Python 3.8
 * [HepMC2](http://hepmc.web.cern.ch/hepmc/) `v2.06.11`
 * [LHAPDF](https://lhapdf.hepforge.org/) `v6.3.0`
@@ -23,7 +23,7 @@ The Docker image contains:
 - Use `docker pull` to pull down the image corresponding to the tag. For example:
 
 ```
-docker pull scailfin/madgraph5-amc-nlo:mg5_amc2.8.1-python3
+docker pull scailfin/madgraph5-amc-nlo:mg5_amc2.8.2-python3
 ```
 
 ## Tests
@@ -31,5 +31,5 @@ docker pull scailfin/madgraph5-amc-nlo:mg5_amc2.8.1-python3
 As an example test you can run the [top mass scan example](https://answers.launchpad.net/mg5amcnlo/+faq/2186) in the `tests` directory inside the Docker container by running the following from the top level directory of this repository
 
 ```
-docker run --rm -v $PWD:$PWD -w $PWD scailfin/madgraph5-amc-nlo:mg5_amc2.8.1-python3 "lhapdf install NNPDF23_lo_as_0130_qed; mg5_aMC tests/test_top_mass_scan.mg5"
+docker run --rm -v $PWD:$PWD -w $PWD scailfin/madgraph5-amc-nlo:mg5_amc2.8.2-python3 "lhapdf install NNPDF23_lo_as_0130_qed; mg5_aMC tests/test_top_mass_scan.mg5"
 ```


### PR DESCRIPTION
Update to release [`v2.8.2` of MadGraph5_aMC-NLO](https://launchpad.net/mg5amcnlo/2.0/2.8.x)

```
* Update to MadGraph5_aMC-NLO v2.8.2
   - c.f. https://launchpad.net/mg5amcnlo/2.0/2.8.x/+download/MG5_aMC_v2.8.2.tar.gz
```