### PR TITLE
feat: Update to mg5_aMC v2.9.2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
         repository: scailfin/madgraph5-amc-nlo
         dockerfile: Dockerfile
-        tags: latest,mg5_amc2.9.1.2,mg5_amc2.9.1.2-python3
+        tags: latest,mg5_amc2.9.2,mg5_amc2.9.2-python3
     - name: Build and Publish to Registry with Release Tag
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v1
@@ -31,5 +31,5 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
         repository: scailfin/madgraph5-amc-nlo
         dockerfile: Dockerfile
-        tags: latest,latest-stable,mg5_amc2.9.1.2,mg5_amc2.9.1.2-python3
+        tags: latest,latest-stable,mg5_amc2.9.2,mg5_amc2.9.2-python3
         tag_with_ref: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -107,7 +107,7 @@ RUN mkdir /code && \
     rm -rf /code
 
 # Install MadGraph5_aMC@NLO for Python 3 and PYTHIA 8 interface
-ARG MG_VERSION=2.9.1.2
+ARG MG_VERSION=2.9.2
 RUN cd /usr/local && \
     wget --quiet https://launchpad.net/mg5amcnlo/2.0/2.9.x/+download/MG5_aMC_v${MG_VERSION}.tar.gz && \
     mkdir -p /usr/local/MG5_aMC && \

--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,10 @@ image:
 	--build-arg FASTJET_VERSION=3.3.4 \
 	--build-arg LHAPDF_VERSION=6.3.0 \
 	--build-arg PYTHIA_VERSION=8243 \
-	--build-arg MG_VERSION=2.9.1.2 \
+	--build-arg MG_VERSION=2.9.2 \
 	-t scailfin/madgraph5-amc-nlo:latest \
-	-t scailfin/madgraph5-amc-nlo:2.9.1.2 \
-	-t scailfin/madgraph5-amc-nlo:2.9.1.2-python3 \
+	-t scailfin/madgraph5-amc-nlo:2.9.2 \
+	-t scailfin/madgraph5-amc-nlo:2.9.2-python3 \
 	--compress
 
 test:
@@ -26,5 +26,5 @@ test:
 	--build-arg FASTJET_VERSION=3.3.4 \
 	--build-arg LHAPDF_VERSION=6.3.0 \
 	--build-arg PYTHIA_VERSION=8243 \
-	--build-arg MG_VERSION=2.9.1.2 \
+	--build-arg MG_VERSION=2.9.2 \
 	-t scailfin/madgraph5-amc-nlo:debug-local

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Docker image for Python 3 compliant [MadGraph5_aMC@NLO](https://launchpad.net/mg
 
 The Docker image contains:
 
-* [MadGraph5_aMC@NLO](https://launchpad.net/mg5amcnlo) `v2.9.1.2`
+* [MadGraph5_aMC@NLO](https://launchpad.net/mg5amcnlo) `v2.9.2`
 * Python 3.8
 * [HepMC2](http://hepmc.web.cern.ch/hepmc/) `v2.06.11`
 * [LHAPDF](https://lhapdf.hepforge.org/) `v6.3.0`
@@ -23,7 +23,7 @@ The Docker image contains:
 - Use `docker pull` to pull down the image corresponding to the tag. For example:
 
 ```
-docker pull scailfin/madgraph5-amc-nlo:mg5_amc2.9.1.2-python3
+docker pull scailfin/madgraph5-amc-nlo:mg5_amc2.9.2-python3
 ```
 
 ## Tests
@@ -31,5 +31,5 @@ docker pull scailfin/madgraph5-amc-nlo:mg5_amc2.9.1.2-python3
 As an example test you can run the [top mass scan example](https://answers.launchpad.net/mg5amcnlo/+faq/2186) in the `tests` directory inside the Docker container by running the following from the top level directory of this repository
 
 ```
-docker run --rm -v $PWD:$PWD -w $PWD scailfin/madgraph5-amc-nlo:mg5_amc2.9.1.2-python3 "lhapdf install NNPDF23_lo_as_0130_qed; mg5_aMC tests/test_top_mass_scan.mg5"
+docker run --rm -v $PWD:$PWD -w $PWD scailfin/madgraph5-amc-nlo:mg5_amc2.9.2-python3 "lhapdf install NNPDF23_lo_as_0130_qed; mg5_aMC tests/test_top_mass_scan.mg5"
 ```


### PR DESCRIPTION
Update to release [`v2.9.2` of MadGraph5_aMC-NLO](https://launchpad.net/mg5amcnlo/2.0/2.9.x).

```
* Update to MadGraph5_aMC-NLO v2.9.2
   - c.f. https://launchpad.net/mg5amcnlo/2.0/2.9.x/+download/MG5_aMC_v2.9.2.tar.gz
```