### PR TITLE
feat: Add non-root default user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -140,12 +140,12 @@ RUN export SED_RANGE="$(($(sed -n '\|enable bash completion in interactive shell
     unset SED_RANGE
 
 # Create user "docker"
-#RUN useradd -m docker && \
-#    cp /root/.bashrc /home/docker/ && \
-#    mkdir /home/docker/data && \
-#    chown -R --from=root docker /home/docker && \
-#    chown -R --from=root docker /usr && \
-#    chown -R --from=root docker /usr/local
+RUN useradd -m docker && \
+   cp /root/.bashrc /home/docker/ && \
+   mkdir /home/docker/data && \
+   chown -R --from=root docker /home/docker && \
+   chown -R --from=root docker /usr && \
+   chown -R --from=root docker /usr/local
 
 ## Move files someplace
 #RUN cp -r /usr/local/MG5_aMC /home/docker/ && \
@@ -165,8 +165,8 @@ RUN cp /root/.profile ${HOME}/.profile && \
     python -m pip install --upgrade --no-cache-dir pip setuptools wheel && \
     python -m pip install --no-cache-dir six numpy
 
-#ENV USER docker
-#USER docker
+ENV USER docker
+USER docker
 ENV PYTHONPATH=/usr/local/lib:/usr/local/MG5_aMC:$PYTHONPATH
 ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 ENV PATH ${HOME}/.local/bin:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -146,12 +146,7 @@ RUN useradd -m docker && \
    chown -R --from=root docker /home/docker && \
    chown -R --from=root docker /usr && \
    chown -hR --from=root docker /usr/local && \
-   chown -hR --from=root docker /usr/local/MG5_aMC && \
-   chown -hR --from=503 docker /usr/local/MG5_aMC
-
-## Move files someplace
-#RUN cp -r /usr/local/MG5_aMC /home/docker/ && \
-#    chown -R --from=root docker /home/docker
+   chown -hR --from=503 docker /usr/local
 
 # Use C.UTF-8 locale to avoid issues with ASCII encoding
 ENV LC_ALL=C.UTF-8

--- a/Dockerfile
+++ b/Dockerfile
@@ -145,7 +145,8 @@ RUN useradd -m docker && \
    mkdir /home/docker/data && \
    chown -R --from=root docker /home/docker && \
    chown -R --from=root docker /usr && \
-   chown -R --from=root docker /usr/local
+   chown -R --from=root docker /usr/local && \
+   chown -R --from=root docker /usr/local/MG5_aMC
 
 ## Move files someplace
 #RUN cp -r /usr/local/MG5_aMC /home/docker/ && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -145,8 +145,9 @@ RUN useradd -m docker && \
    mkdir /home/docker/data && \
    chown -R --from=root docker /home/docker && \
    chown -R --from=root docker /usr && \
-   chown -R --from=root docker /usr/local && \
-   chown -R --from=root docker /usr/local/MG5_aMC
+   chown -hR --from=root docker /usr/local && \
+   chown -hR --from=root docker /usr/local/MG5_aMC && \
+   chown -hR --from=503 docker /usr/local/MG5_aMC
 
 ## Move files someplace
 #RUN cp -r /usr/local/MG5_aMC /home/docker/ && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -145,8 +145,8 @@ RUN useradd -m docker && \
    mkdir /home/docker/data && \
    chown -R --from=root docker /home/docker && \
    chown -R --from=root docker /usr && \
-   chown -hR --from=root docker /usr/local && \
-   chown -hR --from=503 docker /usr/local
+   chown -R --from=root docker /usr/local && \
+   chown -R --from=503 docker /usr/local
 
 # Use C.UTF-8 locale to avoid issues with ASCII encoding
 ENV LC_ALL=C.UTF-8


### PR DESCRIPTION
Resolves #20 

Add a default user, "docker", that is non-root for security, as suggested by @msneubauer.

Example:

```
$ echo $USER
feickert
$ docker run --rm -v $PWD:$PWD -w $PWD scailfin/madgraph5-amc-nlo:mg5_amc2.9.2-python3 'echo "written by user ${USER}"> inside.txt; cat inside.txt'
written by user docker
$ ls -lhtra inside.txt 
-rw-r--r-- 1 feickert feickert 23 Mar  8 21:41 inside.txt
$ cat inside.txt 
written by user docker
```

```
* Add 'docker' non-root default user
```