### PR TITLE
fix: Reduce image size with judicious chown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,8 @@ jobs:
     - name: Run test program
       run: >-
         docker run --rm
+        --user root
         -v $PWD:$PWD
         -w $PWD
         scailfin/madgraph5-amc-nlo:test
-        "echo $PWD; lhapdf install NNPDF23_lo_as_0130_qed; mg5_aMC tests/test_top_mass_scan.mg5"
+        "lhapdf install NNPDF23_lo_as_0130_qed; mg5_aMC tests/test_top_mass_scan.mg5"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,4 +32,4 @@ jobs:
         -v $PWD:$PWD
         -w $PWD
         scailfin/madgraph5-amc-nlo:test
-        "lhapdf install NNPDF23_lo_as_0130_qed; mg5_aMC tests/test_top_mass_scan.mg5"
+        "echo $PWD; lhapdf install NNPDF23_lo_as_0130_qed; mg5_aMC tests/test_top_mass_scan.mg5"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,6 @@ jobs:
     - name: Run test program
       run: >-
         docker run --rm
-        --user root
         -v $PWD:$PWD
-        -w $PWD
         scailfin/madgraph5-amc-nlo:test
-        "lhapdf install NNPDF23_lo_as_0130_qed; mg5_aMC tests/test_top_mass_scan.mg5"
+        "lhapdf install NNPDF23_lo_as_0130_qed; mg5_aMC ${PWD}/tests/test_top_mass_scan.mg5; ls -lhtra"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
   schedule:
   - cron:  '1 0 * * 0'
+  workflow_dispatch:
 
 jobs:
   test:

--- a/Dockerfile
+++ b/Dockerfile
@@ -144,7 +144,6 @@ RUN useradd -m docker && \
    cp /root/.bashrc /home/docker/ && \
    mkdir /home/docker/data && \
    chown -R --from=root docker /home/docker && \
-   chown -R --from=root docker /usr && \
    chown -R --from=root docker /usr/local && \
    chown -R --from=503 docker /usr/local
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -144,8 +144,8 @@ RUN useradd -m docker && \
    cp /root/.bashrc /home/docker/ && \
    mkdir /home/docker/data && \
    chown -R --from=root docker /home/docker && \
-   chown -R --from=root docker /usr/local && \
-   chown -R --from=503 docker /usr/local
+   chown -R --from=root docker /usr/local/MG5_aMC && \
+   chown -R --from=503 docker /usr/local/MG5_aMC
 
 # Use C.UTF-8 locale to avoid issues with ASCII encoding
 ENV LC_ALL=C.UTF-8

--- a/Dockerfile
+++ b/Dockerfile
@@ -145,6 +145,7 @@ RUN useradd -m docker && \
    mkdir /home/docker/data && \
    chown -R --from=root docker /home/docker && \
    chown -R --from=root docker /usr/local/MG5_aMC && \
+   chown -R --from=root docker /usr/local/share && \
    chown -R --from=503 docker /usr/local/MG5_aMC
 
 # Use C.UTF-8 locale to avoid issues with ASCII encoding


### PR DESCRIPTION
Reduce image size by restricting range of `chown` command. 

To be able to write to the default directory areas (under `/github/workspace`) in GHA, Docker [must be run as `root`](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#docker-container-filesystem) as 

> `/github/workspace` - **Note:** GitHub Actions must be run by the default Docker user (root). Ensure your Dockerfile does not set the `USER` instruction, otherwise you will not be able to access `GITHUB_WORKSPACE`.

so to avoid this, don't have the work directory be the `$PWD`, but still bind mount to be able to get the tests into the directory.

```
* Restrict chown to /usr/local/MG5_aMC and /usr/local/share to reduce image size
   - c.f. https://stackoverflow.com/q/30085621/8931942
* Don't set default working directory as PWD to avoid having to run docker as root
   - bind mount to PWD and then use PWD in the path to the tests
   - c.f. https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#docker-container-filesystem
* Add workflow_dispatch to CI
```