### PR TITLE
docs: Add use examples to the README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get -qq -y update && \
       python3-dev \
       wget \
       git && \
-    apt-get -y autoclean && \
+    apt-get -y clean && \
     apt-get -y autoremove && \
     rm -rf /var/lib/apt/lists/*
 

--- a/README.md
+++ b/README.md
@@ -26,12 +26,48 @@ The Docker image contains:
 docker pull scailfin/madgraph5-amc-nlo:mg5_amc2.9.2-python3
 ```
 
+## Use
+
+MadGraph5_aMC@NLO is in `PATH` when the container starts
+
+```shell
+docker run --rm scailfin/madgraph5-amc-nlo:mg5_amc2.9.2-python3 "mg5_aMC --help"
+Usage: mg5_aMC [options] [FILE]
+
+Options:
+  -h, --help            show this help message and exit
+  -l LOGGING, --logging=LOGGING
+                        logging level (DEBUG|INFO|WARNING|ERROR|CRITICAL)
+                        [INFO]
+  -f FILE, --file=FILE  Use script file FILE
+  -d MGME_DIR, --mgme_dir=MGME_DIR
+                        Use MG_ME directory MGME_DIR
+  --web                 force to be in secure mode
+  --debug               force to launch debug mode
+  -m PLUGIN, --mode=PLUGIN
+                        Define some additional command provide by a PLUGIN
+  -s, --nocaffeinate    For mac user, forbids to use caffeinate when running
+                        with a script
+```
+
+so you should be able to make any directory inside the container a working directory and run `mg5_aMC` commands.
+
+When run as a container the
+
+If you run the image as an interactive container
+
+```shell
+docker run --rm -ti scailfin/madgraph5-amc-nlo:mg5_amc2.9.2-python3
+```
+
+you'll be dropped into the container at `/home/docker/data`
+
 ## Tests
 
 As an example test you can run the [top mass scan example](https://answers.launchpad.net/mg5amcnlo/+faq/2186) in the `tests` directory inside the Docker container by running the following from the top level directory of this repository
 
 ```shell
-docker run --pull --rm -v $PWD:$PWD scailfin/madgraph5-amc-nlo:mg5_amc2.9.2-python3 "cd ${PWD}/tests; bash tests.sh"
+docker run --rm -v $PWD:$PWD scailfin/madgraph5-amc-nlo:mg5_amc2.9.2-python3 "cd ${PWD}/tests; bash tests.sh"
 ```
 
 or run the test runner

--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ docker run --rm -ti -v $PWD:$PWD -w $PWD scailfin/madgraph5-amc-nlo:mg5_amc2.9.2
 
 output from your work in that directory in the interactive session will be preserved when the container exists.
 
+The container can be used a runtime application by passing in a MadGraph program as a `.mg5` file to the `mg5_aMC` CLI API
+
+```shell
+docker run --rm -v $PWD:$PWD -w $PWD scailfin/madgraph5-amc-nlo:mg5_amc2.9.2 "mg5_aMC file-name.mg5"
+```
+
+For further examples see the tests.
+
 ## Tests
 
 As an example test you can run the [top mass scan example](https://answers.launchpad.net/mg5amcnlo/+faq/2186) in the `tests` directory inside the Docker container by running the following from the top level directory of this repository

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The Docker image contains:
 - Use `docker pull` to pull down the image corresponding to the tag. For example:
 
 ```
-docker pull scailfin/madgraph5-amc-nlo:mg5_amc2.9.2-python3
+docker pull scailfin/madgraph5-amc-nlo:mg5_amc2.9.2
 ```
 
 ## Use
@@ -31,7 +31,7 @@ docker pull scailfin/madgraph5-amc-nlo:mg5_amc2.9.2-python3
 MadGraph5_aMC@NLO is in `PATH` when the container starts
 
 ```shell
-docker run --rm scailfin/madgraph5-amc-nlo:mg5_amc2.9.2-python3 "mg5_aMC --help"
+docker run --rm scailfin/madgraph5-amc-nlo:mg5_amc2.9.2 "mg5_aMC --help"
 Usage: mg5_aMC [options] [FILE]
 
 Options:
@@ -52,12 +52,10 @@ Options:
 
 so you should be able to make any directory inside the container a working directory and run `mg5_aMC` commands.
 
-When run as a container the
-
-If you run the image as an interactive container
+If you run the image as an interactive container with your local path bind mounted
 
 ```shell
-docker run --rm -ti scailfin/madgraph5-amc-nlo:mg5_amc2.9.2-python3
+docker run --rm -ti scailfin/madgraph5-amc-nlo:mg5_amc2.9.2
 ```
 
 you'll be dropped into the container at `/home/docker/data`
@@ -67,7 +65,7 @@ you'll be dropped into the container at `/home/docker/data`
 As an example test you can run the [top mass scan example](https://answers.launchpad.net/mg5amcnlo/+faq/2186) in the `tests` directory inside the Docker container by running the following from the top level directory of this repository
 
 ```shell
-docker run --rm -v $PWD:$PWD scailfin/madgraph5-amc-nlo:mg5_amc2.9.2-python3 "cd ${PWD}/tests; bash tests.sh"
+docker run --rm -v $PWD:$PWD scailfin/madgraph5-amc-nlo:mg5_amc2.9.2 "cd ${PWD}/tests; bash tests.sh"
 ```
 
 or run the test runner

--- a/README.md
+++ b/README.md
@@ -50,15 +50,15 @@ Options:
                         with a script
 ```
 
-so you should be able to make any directory inside the container a working directory and run `mg5_aMC` commands.
+so you should be able to make any directory inside the container a working directory and run `mg5_aMC` commands from there.
 
-If you run the image as an interactive container with your local path bind mounted
+If you run the image as an interactive container with your local path bind mounted to the working directory
 
 ```shell
-docker run --rm -ti scailfin/madgraph5-amc-nlo:mg5_amc2.9.2
+docker run --rm -ti -v $PWD:$PWD -w $PWD scailfin/madgraph5-amc-nlo:mg5_amc2.9.2
 ```
 
-you'll be dropped into the container at `/home/docker/data`
+output from your work in that directory in the interactive session will be preserved when the container exists.
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ docker pull scailfin/madgraph5-amc-nlo:mg5_amc2.9.2
 
 MadGraph5_aMC@NLO is in `PATH` when the container starts
 
-```shell
+```
 docker run --rm scailfin/madgraph5-amc-nlo:mg5_amc2.9.2 "mg5_aMC --help"
 Usage: mg5_aMC [options] [FILE]
 


### PR DESCRIPTION
```
* Add use examples on running the image as a Docker container and using mg5_aMC
* Use apt-get clean over apt-get autoclean to remove more unused files
```