### PR TITLE
feat: Update to mg5_aMC v3.1.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
         repository: scailfin/madgraph5-amc-nlo
         dockerfile: Dockerfile
-        tags: latest,mg5_amc2.9.2,mg5_amc2.9.2-python3
+        tags: latest,mg5_amc3.1.0,mg5_amc3.1.0-python3
     - name: Build and Publish to Registry with Release Tag
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v1
@@ -31,5 +31,5 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
         repository: scailfin/madgraph5-amc-nlo
         dockerfile: Dockerfile
-        tags: latest,latest-stable,mg5_amc2.9.2,mg5_amc2.9.2-python3
+        tags: latest,latest-stable,mg5_amc3.1.0,mg5_amc3.1.0-python3
         tag_with_ref: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -109,7 +109,7 @@ RUN mkdir /code && \
 # Install MadGraph5_aMC@NLO for Python 3 and PYTHIA 8 interface
 ARG MG_VERSION=3.1.0
 RUN cd /usr/local && \
-    wget --quiet https://launchpad.net/mg5amcnlo/2.0/2.9.x/+download/MG5_aMC_v${MG_VERSION}.tar.gz && \
+    wget --quiet https://launchpad.net/mg5amcnlo/3.0/3.1.x/+download/MG5_aMC_v${MG_VERSION}.tar.gz && \
     mkdir -p /usr/local/MG5_aMC && \
     tar -xzvf MG5_aMC_v${MG_VERSION}.tar.gz --strip=1 --directory=MG5_aMC && \
     rm MG5_aMC_v${MG_VERSION}.tar.gz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -107,7 +107,7 @@ RUN mkdir /code && \
     rm -rf /code
 
 # Install MadGraph5_aMC@NLO for Python 3 and PYTHIA 8 interface
-ARG MG_VERSION=2.9.2
+ARG MG_VERSION=3.1.0
 RUN cd /usr/local && \
     wget --quiet https://launchpad.net/mg5amcnlo/2.0/2.9.x/+download/MG5_aMC_v${MG_VERSION}.tar.gz && \
     mkdir -p /usr/local/MG5_aMC && \

--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,10 @@ image:
 	--build-arg FASTJET_VERSION=3.3.4 \
 	--build-arg LHAPDF_VERSION=6.3.0 \
 	--build-arg PYTHIA_VERSION=8243 \
-	--build-arg MG_VERSION=2.9.2 \
+	--build-arg MG_VERSION=3.1.0 \
 	-t scailfin/madgraph5-amc-nlo:latest \
-	-t scailfin/madgraph5-amc-nlo:2.9.2 \
-	-t scailfin/madgraph5-amc-nlo:2.9.2-python3 \
+	-t scailfin/madgraph5-amc-nlo:3.1.0 \
+	-t scailfin/madgraph5-amc-nlo:3.1.0-python3 \
 	--compress
 
 test:
@@ -26,5 +26,5 @@ test:
 	--build-arg FASTJET_VERSION=3.3.4 \
 	--build-arg LHAPDF_VERSION=6.3.0 \
 	--build-arg PYTHIA_VERSION=8243 \
-	--build-arg MG_VERSION=2.9.2 \
+	--build-arg MG_VERSION=3.1.0 \
 	-t scailfin/madgraph5-amc-nlo:debug-local

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Docker image for Python 3 compliant [MadGraph5_aMC@NLO](https://launchpad.net/mg
 
 The Docker image contains:
 
-* [MadGraph5_aMC@NLO](https://launchpad.net/mg5amcnlo) `v2.9.2`
+* [MadGraph5_aMC@NLO](https://launchpad.net/mg5amcnlo) `v3.1.0`
 * Python 3.8
 * [HepMC2](http://hepmc.web.cern.ch/hepmc/) `v2.06.11`
 * [LHAPDF](https://lhapdf.hepforge.org/) `v6.3.0`
@@ -23,7 +23,7 @@ The Docker image contains:
 - Use `docker pull` to pull down the image corresponding to the tag. For example:
 
 ```
-docker pull scailfin/madgraph5-amc-nlo:mg5_amc2.9.2
+docker pull scailfin/madgraph5-amc-nlo:mg5_amc3.1.0
 ```
 
 ## Use
@@ -31,7 +31,7 @@ docker pull scailfin/madgraph5-amc-nlo:mg5_amc2.9.2
 MadGraph5_aMC@NLO is in `PATH` when the container starts
 
 ```
-docker run --rm scailfin/madgraph5-amc-nlo:mg5_amc2.9.2 "mg5_aMC --help"
+docker run --rm scailfin/madgraph5-amc-nlo:mg5_amc3.1.0 "mg5_aMC --help"
 Usage: mg5_aMC [options] [FILE]
 
 Options:
@@ -55,7 +55,7 @@ so you should be able to make any directory inside the container a working direc
 If you run the image as an interactive container with your local path bind mounted to the working directory
 
 ```shell
-docker run --rm -ti -v $PWD:$PWD -w $PWD scailfin/madgraph5-amc-nlo:mg5_amc2.9.2
+docker run --rm -ti -v $PWD:$PWD -w $PWD scailfin/madgraph5-amc-nlo:mg5_amc3.1.0
 ```
 
 output from your work in that directory in the interactive session will be preserved when the container exists.
@@ -63,7 +63,7 @@ output from your work in that directory in the interactive session will be prese
 The container can be used a runtime application by passing in a MadGraph program as a `.mg5` file to the `mg5_aMC` CLI API
 
 ```shell
-docker run --rm -v $PWD:$PWD -w $PWD scailfin/madgraph5-amc-nlo:mg5_amc2.9.2 "mg5_aMC file-name.mg5"
+docker run --rm -v $PWD:$PWD -w $PWD scailfin/madgraph5-amc-nlo:mg5_amc3.1.0 "mg5_aMC file-name.mg5"
 ```
 
 For further examples see the tests.
@@ -73,7 +73,7 @@ For further examples see the tests.
 As an example test you can run the [top mass scan example](https://answers.launchpad.net/mg5amcnlo/+faq/2186) in the `tests` directory inside the Docker container by running the following from the top level directory of this repository
 
 ```shell
-docker run --rm -v $PWD:$PWD scailfin/madgraph5-amc-nlo:mg5_amc2.9.2 "cd ${PWD}/tests; bash tests.sh"
+docker run --rm -v $PWD:$PWD scailfin/madgraph5-amc-nlo:mg5_amc3.1.0 "cd ${PWD}/tests; bash tests.sh"
 ```
 
 or run the test runner

--- a/test_runner.sh
+++ b/test_runner.sh
@@ -4,7 +4,7 @@ set -e
 set -u
 set -o pipefail
 
-test_image="scailfin/madgraph5-amc-nlo:mg5_amc2.9.2-python3"
+test_image="scailfin/madgraph5-amc-nlo:mg5_amc3.1.0-python3"
 
 docker pull "${test_image}"
 docker run \


### PR DESCRIPTION
Update to release [`v3.1.0` of MadGraph5_aMC-NLO](https://launchpad.net/mg5amcnlo/3.0/3.1.x).

From the [release announcement](https://launchpad.net/mg5amcnlo/+announcement/28491):

> Version 3.x is now out of beta and is the official version of MG5aMC. Version 2.x will not be develop anymore, will not receive any new features but will receive some patches in the next year (up to december 2022) being fully out of support.

```
* Update to MadGraph5_aMC-NLO v3.1.0
   - c.f. https://launchpad.net/mg5amcnlo/3.0/3.1.x/+download/MG5_aMC_v3.1.0.tar.gz
   - c.f. https://launchpad.net/mg5amcnlo/+announcement/28491
```