### PR TITLE
fix: Update to new PYTHIA download URL

### DIFF
--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -88,7 +88,7 @@ ARG PYTHIA_VERSION=8243
 # CentOS 7 gcc v4.8.5 is old enough need to specify -std=c++11
 RUN mkdir /code && \
     cd /code && \
-    wget --quiet "https://pythia.org/download/pythia${PYTHIA_VERSION:2}/pythia${PYTHIA_VERSION}.tgz" && \
+    wget "https://pythia.org/download/pythia${PYTHIA_VERSION:0:2}/pythia${PYTHIA_VERSION}.tgz" && \
     tar xvfz pythia${PYTHIA_VERSION}.tgz && \
     cd pythia${PYTHIA_VERSION} && \
     ./configure --help && \

--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -88,7 +88,7 @@ ARG PYTHIA_VERSION=8243
 # CentOS 7 gcc v4.8.5 is old enough need to specify -std=c++11
 RUN mkdir /code && \
     cd /code && \
-    wget --quiet http://home.thep.lu.se/~torbjorn/pythia8/pythia${PYTHIA_VERSION}.tgz && \
+    wget --quiet "https://pythia.org/download/pythia${PYTHIA_VERSION:2}/pythia${PYTHIA_VERSION}.tgz" && \
     tar xvfz pythia${PYTHIA_VERSION}.tgz && \
     cd pythia${PYTHIA_VERSION} && \
     ./configure --help && \

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -86,7 +86,7 @@ ARG PYTHIA_VERSION=8243
 # PYTHON_VERSION already exists in the base image
 RUN mkdir /code && \
     cd /code && \
-    wget --quiet http://home.thep.lu.se/~torbjorn/pythia8/pythia${PYTHIA_VERSION}.tgz && \
+    wget --quiet "https://pythia.org/download/pythia${PYTHIA_VERSION:2}/pythia${PYTHIA_VERSION}.tgz" && \
     tar xvfz pythia${PYTHIA_VERSION}.tgz && \
     cd pythia${PYTHIA_VERSION} && \
     ./configure --help && \

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -86,7 +86,7 @@ ARG PYTHIA_VERSION=8243
 # PYTHON_VERSION already exists in the base image
 RUN mkdir /code && \
     cd /code && \
-    wget --quiet "https://pythia.org/download/pythia${PYTHIA_VERSION:2}/pythia${PYTHIA_VERSION}.tgz" && \
+    wget --quiet "https://pythia.org/download/pythia${PYTHIA_VERSION:0:2}/pythia${PYTHIA_VERSION}.tgz" && \
     tar xvfz pythia${PYTHIA_VERSION}.tgz && \
     cd pythia${PYTHIA_VERSION} && \
     ./configure --help && \


### PR DESCRIPTION
> PYTHIA has a new address at pythia.org. Please update your bookmarks. If you are not redirected automatically, follow this link to pythia.org.

```
* Update PYTHIA download URL to use new PYTHIA domain of pythia.org
   - Website message from http://home.thep.lu.se/Pythia/: PYTHIA has a new address at pythia.org. Please update your bookmarks. If you are not redirected automatically, follow this link to pythia.org.
```