### PR TITLE
fix: Explicitly set python3 for CentOS

### DIFF
--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -57,7 +57,7 @@ RUN mkdir /code && \
     cd fastjet-${FASTJET_VERSION} && \
     ./configure --help && \
     export CXX=$(which g++) && \
-    export PYTHON=$(which python) && \
+    export PYTHON=/usr/local/bin/python3 && \
     ./configure \
       --prefix=/usr/local \
       --enable-pyext=yes && \
@@ -75,7 +75,7 @@ RUN mkdir /code && \
     cd LHAPDF-${LHAPDF_VERSION} && \
     ./configure --help && \
     export CXX=$(which g++) && \
-    export PYTHON=$(which python) && \
+    export PYTHON=/usr/local/bin/python3 && \
     ./configure \
       --prefix=/usr/local && \
     make -j$(($(nproc) - 1)) && \

--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -22,7 +22,6 @@ RUN yum update -y && \
       bash-completion \
       bash-completion-extras \
       wget \
-      which \
       git && \
     yum clean all && \
     yum autoremove -y

--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -35,7 +35,7 @@ RUN mkdir /code && \
     tar xvfz hepmc${HEPMC_VERSION}.tgz && \
     mv HepMC-${HEPMC_VERSION} src && \
     cmake \
-      -DCMAKE_CXX_COMPILER=$(which g++) \
+      -DCMAKE_CXX_COMPILER=$(command -v g++) \
       -DCMAKE_BUILD_TYPE=Release \
       -Dbuild_docs:BOOL=OFF \
       -Dmomentum:STRING=MEV \
@@ -56,7 +56,7 @@ RUN mkdir /code && \
     tar xvfz fastjet-${FASTJET_VERSION}.tar.gz && \
     cd fastjet-${FASTJET_VERSION} && \
     ./configure --help && \
-    export CXX=$(which g++) && \
+    export CXX=$(command -v g++) && \
     export PYTHON=/usr/local/bin/python3 && \
     ./configure \
       --prefix=/usr/local \
@@ -74,7 +74,7 @@ RUN mkdir /code && \
     tar xvfz LHAPDF-${LHAPDF_VERSION}.tar.gz && \
     cd LHAPDF-${LHAPDF_VERSION} && \
     ./configure --help && \
-    export CXX=$(which g++) && \
+    export CXX=$(command -v g++) && \
     export PYTHON=/usr/local/bin/python3 && \
     ./configure \
       --prefix=/usr/local && \


### PR DESCRIPTION
As programs can use the python runtime to determine other information like the `python-config` file it is better to not try to use `$(command -v python)` as a means of finding this as it might not link to the required files. Instead, explicitly pass the Python 3 runtime desired.

```
* Explicitly set the python3 runtime to use during library configure and build instead of inferring it
   - Use /usr/local/bin/python3 over $(command -v python3)
   - Necessary as python-config.py lives under /usr/local/lib/python3.8 not /usr/local/venv/lib/python3.8/
* Remove use of 'which' in favor of more portable 'command -v'
```