### PR TITLE
fix: Use software prefix of /usr/local/venv for CentOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ test:
 	--build-arg MG_VERSION=3.1.1 \
 	-t scailfin/madgraph5-amc-nlo:debug-local
 
-test-centos: base-centos
+test-centos:
 	docker build . \
 	-f docker/centos/Dockerfile \
 	--build-arg HEPMC_VERSION=2.06.11 \

--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -135,7 +135,7 @@ RUN cd /usr/local/venv && \
 # Change the MadGraph5_aMC@NLO configuration settings
 RUN sed -i '/fastjet =/s/^# //g' /usr/local/venv/MG5_aMC/input/mg5_configuration.txt && \
     sed -i '/lhapdf_py3 =/s/^# //g' /usr/local/venv/MG5_aMC/input/mg5_configuration.txt && \
-    sed -i 's|# pythia8_path.*|pythia8_path = /usr/local|g' /usr/local/venv/MG5_aMC/input/mg5_configuration.txt && \
+    sed -i 's|# pythia8_path.*|pythia8_path = /usr/local/venv|g' /usr/local/venv/MG5_aMC/input/mg5_configuration.txt && \
     sed -i '/mg5amc_py8_interface_path =/s/^# //g' /usr/local/venv/MG5_aMC/input/mg5_configuration.txt
 
 # Create user "docker"

--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -143,6 +143,7 @@ RUN useradd --shell /bin/bash -m docker && \
    cp /root/.bashrc /home/docker/ && \
    mkdir /home/docker/data && \
    chown -R --from=root docker /home/docker && \
+   chown -R --from=root docker /usr/local/venv && \
    chown -R --from=root docker /usr/local/venv/MG5_aMC && \
    chown -R --from=root docker /usr/local/venv/share && \
    chown -R --from=503 docker /usr/local/venv/MG5_aMC

--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -92,7 +92,7 @@ RUN mkdir /code && \
     tar xvfz pythia${PYTHIA_VERSION}.tgz && \
     cd pythia${PYTHIA_VERSION} && \
     ./configure --help && \
-    export PYTHON_MINOR_VERSION=${PYTHON_VERSION::-2} && \
+    export PYTHON_MINOR_VERSION=${PYTHON_VERSION::-3} && \
     ./configure \
       --prefix=/usr/local/venv \
       --arch=Linux \
@@ -104,7 +104,7 @@ RUN mkdir /code && \
       --with-fastjet3 \
       --with-python-bin=/usr/local/venv/bin/ \
       --with-python-lib=/usr/local/venv/lib/python${PYTHON_MINOR_VERSION} \
-      --with-python-include=/usr/local/venv/include/python${PYTHON_MINOR_VERSION} \
+      --with-python-include=/usr/local/include/python${PYTHON_MINOR_VERSION} \
       --cxx-common="-O2 -m64 -pedantic -W -Wall -Wshadow -fPIC -std=c++11" \
       --cxx-shared="-shared -std=c++11" && \
     make -j$(($(nproc) - 1)) && \

--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -159,7 +159,9 @@ RUN if [ -f /root/.profile ];then cp /root/.profile ${HOME}/.profile;fi && \
     echo 'export PATH=${HOME}/.local/bin:$PATH' >> ${HOME}/.bashrc && \
     echo 'export PATH=/usr/local/venv/MG5_aMC/bin:$PATH' >> ${HOME}/.bashrc && \
     python -m pip --no-cache-dir install --upgrade pip setuptools wheel && \
-    python -m pip --no-cache-dir install six numpy
+    python -m pip --no-cache-dir install six numpy && \
+    . ${HOME}/.bashrc && \
+    echo "exit" | mg5_aMC
 
 ENV USER docker
 USER docker

--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -2,7 +2,7 @@ ARG BUILDER_IMAGE=neubauergroup/centos-build-base:latest
 FROM ${BUILDER_IMAGE} as builder
 
 USER root
-WORKDIR /usr/local
+WORKDIR /
 
 SHELL [ "/bin/bash", "-c" ]
 
@@ -39,7 +39,7 @@ RUN mkdir /code && \
       -Dbuild_docs:BOOL=OFF \
       -Dmomentum:STRING=MEV \
       -Dlength:STRING=MM \
-      -DCMAKE_INSTALL_PREFIX=/usr/local \
+      -DCMAKE_INSTALL_PREFIX=/usr/local/venv \
       -S src \
       -B build && \
     cmake build -L && \
@@ -56,9 +56,9 @@ RUN mkdir /code && \
     cd fastjet-${FASTJET_VERSION} && \
     ./configure --help && \
     export CXX=$(command -v g++) && \
-    export PYTHON=/usr/local/bin/python3 && \
+    export PYTHON=$(command -v python3) && \
     ./configure \
-      --prefix=/usr/local \
+      --prefix=/usr/local/venv \
       --enable-pyext=yes && \
     make -j$(($(nproc) - 1)) && \
     make check && \
@@ -74,9 +74,9 @@ RUN mkdir /code && \
     cd LHAPDF-${LHAPDF_VERSION} && \
     ./configure --help && \
     export CXX=$(command -v g++) && \
-    export PYTHON=/usr/local/bin/python3 && \
+    export PYTHON=$(command -v python3) && \
     ./configure \
-      --prefix=/usr/local && \
+      --prefix=/usr/local/venv && \
     make -j$(($(nproc) - 1)) && \
     make install && \
     rm -rf /code
@@ -93,7 +93,7 @@ RUN mkdir /code && \
     ./configure --help && \
     export PYTHON_MINOR_VERSION=${PYTHON_VERSION::-2} && \
     ./configure \
-      --prefix=/usr/local \
+      --prefix=/usr/local/venv \
       --arch=Linux \
       --cxx=g++ \
       --enable-64bit \
@@ -101,9 +101,9 @@ RUN mkdir /code && \
       --with-hepmc2 \
       --with-lhapdf6 \
       --with-fastjet3 \
-      --with-python-bin=/usr/local/bin/ \
-      --with-python-lib=/usr/local/lib/python${PYTHON_MINOR_VERSION} \
-      --with-python-include=/usr/local/include/python${PYTHON_MINOR_VERSION} \
+      --with-python-bin=/usr/local/venv/bin/ \
+      --with-python-lib=/usr/local/venv/lib/python${PYTHON_MINOR_VERSION} \
+      --with-python-include=/usr/local/venv/include/python${PYTHON_MINOR_VERSION} \
       --cxx-common="-O2 -m64 -pedantic -W -Wall -Wshadow -fPIC -std=c++11" \
       --cxx-shared="-shared -std=c++11" && \
     make -j$(($(nproc) - 1)) && \
@@ -112,9 +112,9 @@ RUN mkdir /code && \
 
 # Install MadGraph5_aMC@NLO for Python 3 and PYTHIA 8 interface
 ARG MG_VERSION=3.1.1
-RUN cd /usr/local && \
+RUN cd /usr/local/venv && \
     wget --quiet https://launchpad.net/mg5amcnlo/3.0/3.1.x/+download/MG5_aMC_v${MG_VERSION}.tar.gz && \
-    mkdir -p /usr/local/MG5_aMC && \
+    mkdir -p /usr/local/venv/MG5_aMC && \
     tar -xzvf MG5_aMC_v${MG_VERSION}.tar.gz --strip=1 --directory=MG5_aMC && \
     rm MG5_aMC_v${MG_VERSION}.tar.gz && \
     echo "Installing MG5aMC_PY8_interface" && \
@@ -124,27 +124,27 @@ RUN cd /usr/local && \
     mkdir -p /code/MG5aMC_PY8_interface && \
     tar -xzvf MG5aMC_PY8_interface_V1.0.tar.gz --directory=MG5aMC_PY8_interface && \
     cd MG5aMC_PY8_interface && \
-    python compile.py /usr/local/ --pythia8_makefile && \
-    mkdir -p /usr/local/MG5_aMC/HEPTools/MG5aMC_PY8_interface && \
-    cp *.h /usr/local/MG5_aMC/HEPTools/MG5aMC_PY8_interface/ && \
-    cp *_VERSION_ON_INSTALL /usr/local/MG5_aMC/HEPTools/MG5aMC_PY8_interface/ && \
-    cp MG5aMC_PY8_interface /usr/local/MG5_aMC/HEPTools/MG5aMC_PY8_interface/ && \
+    python compile.py /usr/local/venv/ --pythia8_makefile && \
+    mkdir -p /usr/local/venv/MG5_aMC/HEPTools/MG5aMC_PY8_interface && \
+    cp *.h /usr/local/venv/MG5_aMC/HEPTools/MG5aMC_PY8_interface/ && \
+    cp *_VERSION_ON_INSTALL /usr/local/venv/MG5_aMC/HEPTools/MG5aMC_PY8_interface/ && \
+    cp MG5aMC_PY8_interface /usr/local/venv/MG5_aMC/HEPTools/MG5aMC_PY8_interface/ && \
     rm -rf /code
 
 # Change the MadGraph5_aMC@NLO configuration settings
-RUN sed -i '/fastjet =/s/^# //g' /usr/local/MG5_aMC/input/mg5_configuration.txt && \
-    sed -i '/lhapdf_py3 =/s/^# //g' /usr/local/MG5_aMC/input/mg5_configuration.txt && \
-    sed -i 's|# pythia8_path.*|pythia8_path = /usr/local|g' /usr/local/MG5_aMC/input/mg5_configuration.txt && \
-    sed -i '/mg5amc_py8_interface_path =/s/^# //g' /usr/local/MG5_aMC/input/mg5_configuration.txt
+RUN sed -i '/fastjet =/s/^# //g' /usr/local/venv/MG5_aMC/input/mg5_configuration.txt && \
+    sed -i '/lhapdf_py3 =/s/^# //g' /usr/local/venv/MG5_aMC/input/mg5_configuration.txt && \
+    sed -i 's|# pythia8_path.*|pythia8_path = /usr/local|g' /usr/local/venv/MG5_aMC/input/mg5_configuration.txt && \
+    sed -i '/mg5amc_py8_interface_path =/s/^# //g' /usr/local/venv/MG5_aMC/input/mg5_configuration.txt
 
 # Create user "docker"
 RUN useradd --shell /bin/bash -m docker && \
    cp /root/.bashrc /home/docker/ && \
    mkdir /home/docker/data && \
    chown -R --from=root docker /home/docker && \
-   chown -R --from=root docker /usr/local/MG5_aMC && \
-   chown -R --from=root docker /usr/local/share && \
-   chown -R --from=503 docker /usr/local/MG5_aMC
+   chown -R --from=root docker /usr/local/venv/MG5_aMC && \
+   chown -R --from=root docker /usr/local/venv/share && \
+   chown -R --from=503 docker /usr/local/venv/MG5_aMC
 
 # Use en_US.utf8 locale to avoid issues with ASCII encoding
 # as C.UTF-8 not available on CentOS 7
@@ -157,16 +157,16 @@ RUN if [ -f /root/.profile ];then cp /root/.profile ${HOME}/.profile;fi && \
     cp /root/.bashrc ${HOME}/.bashrc && \
     echo "" >> ${HOME}/.bashrc && \
     echo 'export PATH=${HOME}/.local/bin:$PATH' >> ${HOME}/.bashrc && \
-    echo 'export PATH=/usr/local/MG5_aMC/bin:$PATH' >> ${HOME}/.bashrc && \
+    echo 'export PATH=/usr/local/venv/MG5_aMC/bin:$PATH' >> ${HOME}/.bashrc && \
     python -m pip --no-cache-dir install --upgrade pip setuptools wheel && \
     python -m pip --no-cache-dir install six numpy
 
 ENV USER docker
 USER docker
-ENV PYTHONPATH=/usr/local/lib:/usr/local/MG5_aMC:$PYTHONPATH
-ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+ENV PYTHONPATH=/usr/local/venv/lib:/usr/local/venv/MG5_aMC:$PYTHONPATH
+ENV LD_LIBRARY_PATH=/usr/local/venv/lib:$LD_LIBRARY_PATH
 ENV PATH=${HOME}/.local/bin:$PATH
-ENV PATH=/usr/local/MG5_aMC/bin:$PATH
+ENV PATH=/usr/local/venv/MG5_aMC/bin:$PATH
 
 ENTRYPOINT ["/bin/bash", "-l", "-c"]
 CMD ["/bin/bash"]

--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -57,6 +57,7 @@ RUN mkdir /code && \
     ./configure --help && \
     export CXX=$(command -v g++) && \
     export PYTHON=$(command -v python3) && \
+    export PYTHON_CONFIG=$(find /usr/local/ -iname "python-config.py") && \
     ./configure \
       --prefix=/usr/local/venv \
       --enable-pyext=yes && \

--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -144,8 +144,6 @@ RUN useradd --shell /bin/bash -m docker && \
    mkdir /home/docker/data && \
    chown -R --from=root docker /home/docker && \
    chown -R --from=root docker /usr/local/venv && \
-   chown -R --from=root docker /usr/local/venv/MG5_aMC && \
-   chown -R --from=root docker /usr/local/venv/share && \
    chown -R --from=503 docker /usr/local/venv/MG5_aMC
 
 # Use en_US.utf8 locale to avoid issues with ASCII encoding

--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -99,9 +99,9 @@ RUN mkdir /code && \
       --cxx=g++ \
       --enable-64bit \
       --with-gzip \
-      --with-hepmc2 \
-      --with-lhapdf6 \
-      --with-fastjet3 \
+      --with-hepmc2=/usr/local/venv \
+      --with-lhapdf6=/usr/local/venv \
+      --with-fastjet3=/usr/local/venv \
       --with-python-bin=/usr/local/venv/bin/ \
       --with-python-lib=/usr/local/venv/lib/python${PYTHON_MINOR_VERSION} \
       --with-python-include=/usr/local/include/python${PYTHON_MINOR_VERSION} \


### PR DESCRIPTION
```
* Use install prefix for user installed software of /usr/local/venv
   - Python  bindings will pickup the default virtual environment
   - Apply to CentOS 7 based image only at this point
* Run mg5_aMC during image build to create directory structure for all MadGraph5 tooling under /usr/local/venv/MG5_aMC/
   - The first invocation of mg5_aMC in a new working directory creates directories for tools if they don't exist yet
```