### PR TITLE
refactor: Remove exports in .bashrc through setting ENV variables sooner

### DIFF
--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -143,6 +143,7 @@ RUN useradd --shell /bin/bash -m docker && \
    cp /root/.bashrc /home/docker/ && \
    mkdir /home/docker/data && \
    chown -R --from=root docker /home/docker && \
+   chown -R --from=root docker /home/docker/data && \
    chown -R --from=root docker /usr/local/venv && \
    chown -R --from=503 docker /usr/local/venv/MG5_aMC
 
@@ -153,22 +154,24 @@ ENV LANG=en_US.utf8
 
 ENV HOME /home/docker
 WORKDIR ${HOME}/data
+
+# ENV PYTHONPATH=/usr/local/venv/lib:/usr/local/venv/MG5_aMC:$PYTHONPATH
+ENV PYTHONPATH=/usr/local/venv/lib:${PYTHONPATH}
+# ENV LD_LIBRARY_PATH=/usr/local/venv/lib:$LD_LIBRARY_PATH
+ENV PATH=${HOME}/.local/bin:$PATH
+ENV PATH=/usr/local/venv/MG5_aMC/bin:$PATH
+
 RUN if [ -f /root/.profile ];then cp /root/.profile ${HOME}/.profile;fi && \
     cp /root/.bashrc ${HOME}/.bashrc && \
-    echo "" >> ${HOME}/.bashrc && \
-    echo 'export PATH=${HOME}/.local/bin:$PATH' >> ${HOME}/.bashrc && \
-    echo 'export PATH=/usr/local/venv/MG5_aMC/bin:$PATH' >> ${HOME}/.bashrc && \
+    # echo "" >> ${HOME}/.bashrc && \
+    # echo 'export PATH=${HOME}/.local/bin:$PATH' >> ${HOME}/.bashrc && \
+    # echo 'export PATH=/usr/local/venv/MG5_aMC/bin:$PATH' >> ${HOME}/.bashrc && \
     python -m pip --no-cache-dir install --upgrade pip setuptools wheel && \
     python -m pip --no-cache-dir install six numpy && \
-    . ${HOME}/.bashrc && \
     echo "exit" | mg5_aMC
 
 ENV USER docker
 USER docker
-# ENV PYTHONPATH=/usr/local/venv/lib:/usr/local/venv/MG5_aMC:$PYTHONPATH
-# ENV LD_LIBRARY_PATH=/usr/local/venv/lib:$LD_LIBRARY_PATH
-ENV PATH=${HOME}/.local/bin:$PATH
-ENV PATH=/usr/local/venv/MG5_aMC/bin:$PATH
 
 ENTRYPOINT ["/bin/bash", "-l", "-c"]
 CMD ["/bin/bash"]

--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -143,7 +143,6 @@ RUN useradd --shell /bin/bash -m docker && \
    cp /root/.bashrc /home/docker/ && \
    mkdir /home/docker/data && \
    chown -R --from=root docker /home/docker && \
-   chown -R --from=root docker /home/docker/data && \
    chown -R --from=root docker /usr/local/venv && \
    chown -R --from=503 docker /usr/local/venv/MG5_aMC
 
@@ -168,7 +167,8 @@ RUN if [ -f /root/.profile ];then cp /root/.profile ${HOME}/.profile;fi && \
     # echo 'export PATH=/usr/local/venv/MG5_aMC/bin:$PATH' >> ${HOME}/.bashrc && \
     python -m pip --no-cache-dir install --upgrade pip setuptools wheel && \
     python -m pip --no-cache-dir install six numpy && \
-    echo "exit" | mg5_aMC
+    echo "exit" | mg5_aMC && \
+    rm py.py
 
 ENV USER docker
 USER docker

--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -165,8 +165,8 @@ RUN if [ -f /root/.profile ];then cp /root/.profile ${HOME}/.profile;fi && \
 
 ENV USER docker
 USER docker
-ENV PYTHONPATH=/usr/local/venv/lib:/usr/local/venv/MG5_aMC:$PYTHONPATH
-ENV LD_LIBRARY_PATH=/usr/local/venv/lib:$LD_LIBRARY_PATH
+# ENV PYTHONPATH=/usr/local/venv/lib:/usr/local/venv/MG5_aMC:$PYTHONPATH
+# ENV LD_LIBRARY_PATH=/usr/local/venv/lib:$LD_LIBRARY_PATH
 ENV PATH=${HOME}/.local/bin:$PATH
 ENV PATH=/usr/local/venv/MG5_aMC/bin:$PATH
 

--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -154,17 +154,12 @@ ENV LANG=en_US.utf8
 ENV HOME /home/docker
 WORKDIR ${HOME}/data
 
-# ENV PYTHONPATH=/usr/local/venv/lib:/usr/local/venv/MG5_aMC:$PYTHONPATH
 ENV PYTHONPATH=/usr/local/venv/lib:${PYTHONPATH}
-# ENV LD_LIBRARY_PATH=/usr/local/venv/lib:$LD_LIBRARY_PATH
 ENV PATH=${HOME}/.local/bin:$PATH
 ENV PATH=/usr/local/venv/MG5_aMC/bin:$PATH
 
 RUN if [ -f /root/.profile ];then cp /root/.profile ${HOME}/.profile;fi && \
     cp /root/.bashrc ${HOME}/.bashrc && \
-    # echo "" >> ${HOME}/.bashrc && \
-    # echo 'export PATH=${HOME}/.local/bin:$PATH' >> ${HOME}/.bashrc && \
-    # echo 'export PATH=/usr/local/venv/MG5_aMC/bin:$PATH' >> ${HOME}/.bashrc && \
     python -m pip --no-cache-dir install --upgrade pip setuptools wheel && \
     python -m pip --no-cache-dir install six numpy && \
     echo "exit" | mg5_aMC && \


### PR DESCRIPTION
```
* Set PYTHONPATH and PATH before running mg5_aMC first time to avoid .bashrc additions
* Cleanup py.py from first time running mg5_aMC
```