### PR TITLE
fig: Add MadGraph5 directory to PYTHONPATH

### DIFF
--- a/.github/workflows/docker-centos.yml
+++ b/.github/workflows/docker-centos.yml
@@ -91,6 +91,14 @@ jobs:
       - name: List built images
         run: docker images
 
+      - name: Run pytest tests
+        # Need to run not below PWD to have non-root write with GHA
+        run: >-
+          docker run --rm
+          -v $PWD:$PWD
+          scailfin/madgraph5-amc-nlo-centos:sha-${GITHUB_SHA::8}
+          "cp -r ${PWD}/tests .; python -m pip install pytest && pytest tests"
+
       - name: Run test program
         # Need to run not below PWD to have non-root write with GHA
         run: >-

--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -173,7 +173,7 @@ ENV LANG=en_US.utf8
 ENV HOME /home/docker
 WORKDIR ${HOME}/data
 
-ENV PYTHONPATH=/usr/local/venv/lib:${PYTHONPATH}
+ENV PYTHONPATH=/usr/local/venv/MG5_aMC:/usr/local/venv/lib:${PYTHONPATH}
 ENV PATH=${HOME}/.local/bin:$PATH
 ENV PATH=/usr/local/venv/MG5_aMC/bin:$PATH
 

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,0 +1,4 @@
+def test_import_madgraph():
+    import madgraph
+
+    assert madgraph


### PR DESCRIPTION
```
* Add MadGraph5 directory (/usr/local/venv/MG5_aMC) to PYTHONPATH so that madgraph can be imported as a Python module
   - Partially reverts PR #35
* Add pytest test to CI which imports madgraph
```