### PR TITLE
fix: Set default user as root and place libraries on LD_LIBRARY_PATH

### DIFF
--- a/.github/workflows/docker-centos.yml
+++ b/.github/workflows/docker-centos.yml
@@ -2,10 +2,10 @@ name: Docker Images CentOS
 
 on:
   push:
-    # branches:
-    # - main
-    # tags:
-    # - v*
+    branches:
+    - main
+    tags:
+    - v*
   pull_request:
     branches:
     - main
@@ -109,7 +109,7 @@ jobs:
 
       - name: Build and publish to registry
         # every PR will trigger a push event on main, so check the push event is actually coming from main
-        # if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'scailfin/MadGraph5_aMC-NLO'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'scailfin/MadGraph5_aMC-NLO'
         id: docker_build_latest
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/docker-centos.yml
+++ b/.github/workflows/docker-centos.yml
@@ -2,10 +2,10 @@ name: Docker Images CentOS
 
 on:
   push:
-    branches:
-    - main
-    tags:
-    - v*
+    # branches:
+    # - main
+    # tags:
+    # - v*
   pull_request:
     branches:
     - main
@@ -109,7 +109,7 @@ jobs:
 
       - name: Build and publish to registry
         # every PR will trigger a push event on main, so check the push event is actually coming from main
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'scailfin/MadGraph5_aMC-NLO'
+        # if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'scailfin/MadGraph5_aMC-NLO'
         id: docker_build_latest
         uses: docker/build-push-action@v2
         with:

--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -179,7 +179,6 @@ ENV PATH=/usr/local/venv/MG5_aMC/bin:$PATH
 
 RUN if [ -f /root/.profile ];then cp /root/.profile ${HOME}/.profile;fi && \
     cp /root/.bashrc ${HOME}/.bashrc && \
-    printf "\nsource scl_source enable devtoolset-8\n" >> /root/.bash_profile && \
     printf "\nsource scl_source enable devtoolset-8\n" >> ${HOME}/.bash_profile && \
     python -m pip --no-cache-dir install --upgrade pip setuptools wheel && \
     python -m pip --no-cache-dir install six numpy && \

--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -174,6 +174,7 @@ ENV HOME /home/docker
 WORKDIR ${HOME}/data
 
 ENV PYTHONPATH=/usr/local/venv/MG5_aMC:/usr/local/venv/lib:${PYTHONPATH}
+ENV LD_LIBRARY_PATH=/usr/local/venv/lib:$LD_LIBRARY_PATH
 ENV PATH=${HOME}/.local/bin:/root/.local/bin:$PATH
 ENV PATH=/usr/local/venv/MG5_aMC/bin:$PATH
 

--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -186,7 +186,7 @@ RUN if [ -f /root/.profile ];then cp /root/.profile ${HOME}/.profile;fi && \
     rm py.py
 
 ENV USER docker
-USER docker
+USER root
 
 ENTRYPOINT ["/bin/bash", "-l", "-c"]
 CMD ["/bin/bash"]

--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -157,7 +157,7 @@ RUN sed -i '/fastjet =/s/^# //g' /usr/local/venv/MG5_aMC/input/mg5_configuration
     sed -i 's|# pythia8_path.*|pythia8_path = /usr/local/venv|g' /usr/local/venv/MG5_aMC/input/mg5_configuration.txt && \
     sed -i '/mg5amc_py8_interface_path =/s/^# //g' /usr/local/venv/MG5_aMC/input/mg5_configuration.txt
 
-# Create user "docker"
+# Create non-root user "docker"
 RUN useradd --shell /bin/bash -m docker && \
    cp /root/.bashrc /home/docker/ && \
    mkdir /home/docker/data && \
@@ -174,19 +174,23 @@ ENV HOME /home/docker
 WORKDIR ${HOME}/data
 
 ENV PYTHONPATH=/usr/local/venv/MG5_aMC:/usr/local/venv/lib:${PYTHONPATH}
-ENV PATH=${HOME}/.local/bin:$PATH
+ENV PATH=${HOME}/.local/bin:/root/.local/bin:$PATH
 ENV PATH=/usr/local/venv/MG5_aMC/bin:$PATH
 
 RUN if [ -f /root/.profile ];then cp /root/.profile ${HOME}/.profile;fi && \
     cp /root/.bashrc ${HOME}/.bashrc && \
+    printf "\nsource scl_source enable devtoolset-8\n" >> /root/.bash_profile && \
     printf "\nsource scl_source enable devtoolset-8\n" >> ${HOME}/.bash_profile && \
     python -m pip --no-cache-dir install --upgrade pip setuptools wheel && \
     python -m pip --no-cache-dir install six numpy && \
     echo "exit" | mg5_aMC && \
     rm py.py
 
-ENV USER docker
+# Default user is root to avoid uid write permission problems with volumes
 USER root
+ENV USER root
+ENV HOME /root
+WORKDIR ${HOME}/data
 
 ENTRYPOINT ["/bin/bash", "-l", "-c"]
 CMD ["/bin/bash"]

--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -187,8 +187,6 @@ RUN if [ -f /root/.profile ];then cp /root/.profile ${HOME}/.profile;fi && \
     rm py.py
 
 # Default user is root to avoid uid write permission problems with volumes
-USER root
-ENV USER root
 ENV HOME /root
 WORKDIR ${HOME}/data
 

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -2,3 +2,21 @@ def test_import_madgraph():
     import madgraph
 
     assert madgraph
+
+
+def test_import_lhapdf():
+    import lhapdf
+
+    assert lhapdf
+
+
+def test_import_pythia():
+    import pythia8
+
+    assert pythia8
+
+
+def test_import_fastjet():
+    import fastjet
+
+    assert fastjet


### PR DESCRIPTION
Resolves #38

```
* Set default user as root
   - If default user is non-root they will have no write capabilities to volume mounts
   - c.f. https://github.com/moby/moby/issues/2259
   - Partially reverts PR #22
* Place user installed libraries (in /usr/local/venv/lib) on LD_LIBRARY_PATH so they are findable by Python
* Add Python import tests for LHAPDF, PYTHIA8, and FastJet
```