### PR TITLE
feat: Add ghostscript as default PostScript viewer

### DIFF
--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -22,6 +22,7 @@ RUN yum update -y && \
       bash-completion \
       bash-completion-extras \
       wget \
+      ghostscript \
       git && \
     yum clean all && \
     yum autoremove -y

--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -156,7 +156,8 @@ RUN cd /usr/local/venv && \
 RUN sed -i '/fastjet =/s/^# //g' /usr/local/venv/MG5_aMC/input/mg5_configuration.txt && \
     sed -i '/lhapdf_py3 =/s/^# //g' /usr/local/venv/MG5_aMC/input/mg5_configuration.txt && \
     sed -i 's|# pythia8_path.*|pythia8_path = /usr/local/venv|g' /usr/local/venv/MG5_aMC/input/mg5_configuration.txt && \
-    sed -i '/mg5amc_py8_interface_path =/s/^# //g' /usr/local/venv/MG5_aMC/input/mg5_configuration.txt
+    sed -i '/mg5amc_py8_interface_path =/s/^# //g' /usr/local/venv/MG5_aMC/input/mg5_configuration.txt && \
+    sed -i 's|# eps_viewer.*|eps_viewer = '$(command -v ghostscript)'|g' /usr/local/MG5_aMC/input/mg5_configuration.txt
 
 # Create non-root user "docker"
 RUN useradd --shell /bin/bash -m docker && \

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get -qq -y update && \
       bash-completion \
       python3-dev \
       wget \
+      ghostscript \
       git && \
     apt-get -y clean && \
     apt-get -y autoremove && \

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -133,7 +133,8 @@ RUN cd /usr/local && \
 RUN sed -i '/fastjet =/s/^# //g' /usr/local/MG5_aMC/input/mg5_configuration.txt && \
     sed -i '/lhapdf_py3 =/s/^# //g' /usr/local/MG5_aMC/input/mg5_configuration.txt && \
     sed -i 's|# pythia8_path.*|pythia8_path = /usr/local|g' /usr/local/MG5_aMC/input/mg5_configuration.txt && \
-    sed -i '/mg5amc_py8_interface_path =/s/^# //g' /usr/local/MG5_aMC/input/mg5_configuration.txt
+    sed -i '/mg5amc_py8_interface_path =/s/^# //g' /usr/local/MG5_aMC/input/mg5_configuration.txt && \
+    sed -i 's|# eps_viewer.*|eps_viewer = '$(command -v ghostscript)'|g' /usr/local/MG5_aMC/input/mg5_configuration.txt
 
 # Enable tab completion by uncommenting it from /etc/bash.bashrc
 # The relevant lines are those below the phrase "enable bash completion in interactive shells"


### PR DESCRIPTION
Add `ghostscript` so there is a default PostScipt viewer installed to generate the Feynman diagram previews in the summary webpage. Note that the `.eps` files that are the source for the generated `.jpg` files exist under `/tmp/`.

```
* Add ghostscript to use as a PostScipt viewer to create the Feynman diagram previews of the processes
   - Note that the `.eps` files that are the source for the generated `.jpg` files exist under /tmp/
* Set ghostscript as the default PostScipt viewer in mg5_configuration.txt
```