### PR TITLE
chore: Define OS in base image tag of Dockerfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all: image
 image:
 	docker build . \
 	-f docker/debian/Dockerfile \
-	--build-arg BUILDER_IMAGE=python:3.8-slim-bullseye \
+	--build-arg BUILDER_IMAGE=python:3.8-slim-buster \
 	--build-arg HEPMC_VERSION=2.06.11 \
 	--build-arg FASTJET_VERSION=3.3.4 \
 	--build-arg LHAPDF_VERSION=6.3.0 \
@@ -19,7 +19,7 @@ image:
 test:
 	docker build . \
 	-f docker/debian/Dockerfile \
-	--build-arg BUILDER_IMAGE=python:3.8-slim-bullseye \
+	--build-arg BUILDER_IMAGE=python:3.8-slim-buster \
 	--build-arg HEPMC_VERSION=2.06.11 \
 	--build-arg FASTJET_VERSION=3.3.4 \
 	--build-arg LHAPDF_VERSION=6.3.0 \

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all: image
 image:
 	docker build . \
 	-f docker/debian/Dockerfile \
-	--build-arg BUILDER_IMAGE=python:3.8-slim \
+	--build-arg BUILDER_IMAGE=python:3.8-slim-buster \
 	--build-arg HEPMC_VERSION=2.06.11 \
 	--build-arg FASTJET_VERSION=3.3.4 \
 	--build-arg LHAPDF_VERSION=6.3.0 \
@@ -19,7 +19,7 @@ image:
 test:
 	docker build . \
 	-f docker/debian/Dockerfile \
-	--build-arg BUILDER_IMAGE=python:3.8-slim \
+	--build-arg BUILDER_IMAGE=python:3.8-slim-buster \
 	--build-arg HEPMC_VERSION=2.06.11 \
 	--build-arg FASTJET_VERSION=3.3.4 \
 	--build-arg LHAPDF_VERSION=6.3.0 \

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all: image
 image:
 	docker build . \
 	-f docker/debian/Dockerfile \
-	--build-arg BUILDER_IMAGE=python:3.8-slim-buster \
+	--build-arg BUILDER_IMAGE=python:3.8-slim-bullseye \
 	--build-arg HEPMC_VERSION=2.06.11 \
 	--build-arg FASTJET_VERSION=3.3.4 \
 	--build-arg LHAPDF_VERSION=6.3.0 \
@@ -19,7 +19,7 @@ image:
 test:
 	docker build . \
 	-f docker/debian/Dockerfile \
-	--build-arg BUILDER_IMAGE=python:3.8-slim-buster \
+	--build-arg BUILDER_IMAGE=python:3.8-slim-bullseye \
 	--build-arg HEPMC_VERSION=2.06.11 \
 	--build-arg FASTJET_VERSION=3.3.4 \
 	--build-arg LHAPDF_VERSION=6.3.0 \

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILDER_IMAGE=python:3.8-slim
+ARG BUILDER_IMAGE=python:3.8-slim-buster
 FROM ${BUILDER_IMAGE} as builder
 
 USER root

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILDER_IMAGE=python:3.8-slim-buster
+ARG BUILDER_IMAGE=python:3.8-slim-bullseye
 FROM ${BUILDER_IMAGE} as builder
 
 USER root

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILDER_IMAGE=python:3.8-slim-bullseye
+ARG BUILDER_IMAGE=python:3.8-slim-buster
 FROM ${BUILDER_IMAGE} as builder
 
 USER root


### PR DESCRIPTION
Update the base image of the Dockerfile from `python:3.8-slim` to `python:3.8-slim-buster` to ensure that the OS is set and can only be updated through a manual update process. This provides greater package stability.

c.f. https://gitlab.cern.ch/atlas-amglab/atlstats/-/merge_requests/47

```
* Use python:3.8-slim-buster as the base image for the Dockerfile to ensure package stability
   - Packages on distributions of OSes are not all released at the same time and updating OS versions without necessary packages being available can break Docker builds
   - c.f. https://gitlab.cern.ch/atlas-amglab/atlstats/-/merge_requests/47
```