### PR TITLE
fix: Add bc for NLO processes

### DIFF
--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -23,6 +23,7 @@ RUN yum update -y && \
       bash-completion-extras \
       wget \
       ghostscript \
+      bc \
       git && \
     yum clean all && \
     yum autoremove -y

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get -qq -y update && \
       python3-dev \
       wget \
       ghostscript \
+      bc \
       git && \
     apt-get -y clean && \
     apt-get -y autoremove && \


### PR DESCRIPTION
Resolves #46 

For NLO processes MadGraph5 is apparently using `bc` internally, which is currently not installed.

```
* Install bc for use in NLO process computation
```