### PR TITLE
feat: Add optional non-root user and use prefix of /usr/local/venv for Debian images

### DIFF
--- a/.github/workflows/docker-debian.yml
+++ b/.github/workflows/docker-debian.yml
@@ -97,6 +97,14 @@ jobs:
           scailfin/madgraph5-amc-nlo:sha-${GITHUB_SHA::8}
           'cat $(find /usr/local/ -name "mg5_configuration.txt")'
 
+      - name: Run pytest tests
+        # Need to run not below PWD to have non-root write with GHA
+        run: >-
+          docker run --rm
+          -v $PWD:$PWD
+          scailfin/madgraph5-amc-nlo:sha-${GITHUB_SHA::8}
+          "cp -r ${PWD}/tests .; python -m pip install pytest && pytest tests"
+
       - name: Run test program
         # Need to run not below PWD to have non-root write with GHA
         run: >-

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -49,7 +49,7 @@ RUN mkdir /code && \
       -Dbuild_docs:BOOL=OFF \
       -Dmomentum:STRING=MEV \
       -Dlength:STRING=MM \
-      -DCMAKE_INSTALL_PREFIX=/usr/local \
+      -DCMAKE_INSTALL_PREFIX=/usr/local/venv \
       -S src \
       -B build && \
     cmake build -L && \
@@ -68,7 +68,7 @@ RUN mkdir /code && \
     export CXX=$(which g++) && \
     export PYTHON=$(which python) && \
     ./configure \
-      --prefix=/usr/local \
+      --prefix=/usr/local/venv \
       --enable-pyext=yes && \
     make -j$(($(nproc) - 1)) && \
     make check && \
@@ -86,7 +86,7 @@ RUN mkdir /code && \
     export CXX=$(which g++) && \
     export PYTHON=$(which python) && \
     ./configure \
-      --prefix=/usr/local && \
+      --prefix=/usr/local/venv && \
     make -j$(($(nproc) - 1)) && \
     make install && \
     rm -rf /code
@@ -102,7 +102,7 @@ RUN mkdir /code && \
     ./configure --help && \
     export PYTHON_MINOR_VERSION=${PYTHON_VERSION::-3} && \
     ./configure \
-      --prefix=/usr/local \
+      --prefix=/usr/local/venv \
       --arch=Linux \
       --cxx=g++ \
       --enable-64bit \
@@ -110,9 +110,9 @@ RUN mkdir /code && \
       --with-hepmc2 \
       --with-lhapdf6 \
       --with-fastjet3 \
-      --with-python-bin=/usr/local/bin/ \
-      --with-python-lib=/usr/local/lib/python${PYTHON_MINOR_VERSION} \
-      --with-python-include=/usr/local/include/python${PYTHON_MINOR_VERSION} && \
+      --with-python-bin=/usr/local/venv/bin/ \
+      --with-python-lib=/usr/local/venv/lib/python${PYTHON_MINOR_VERSION} \
+      --with-python-include=/usr/local/venv/include/python${PYTHON_MINOR_VERSION} && \
     make -j$(($(nproc) - 1)) && \
     make install && \
     rm -rf /code
@@ -122,9 +122,9 @@ ARG MG_VERSION=3.2.0
 # Versions viewable on Illinois mirror
 # http://madgraph.physics.illinois.edu/Downloads/MG5aMC_PY8_interface/
 ARG MG5aMC_PY8_INTERFACE_VERSION=1.2
-RUN cd /usr/local && \
+RUN cd /usr/local/venv && \
     wget --quiet https://launchpad.net/mg5amcnlo/3.0/3.2.x/+download/MG5_aMC_v${MG_VERSION}.tar.gz && \
-    mkdir -p /usr/local/MG5_aMC && \
+    mkdir -p /usr/local/venv/MG5_aMC && \
     tar -xzvf MG5_aMC_v${MG_VERSION}.tar.gz --strip=1 --directory=MG5_aMC && \
     rm MG5_aMC_v${MG_VERSION}.tar.gz && \
     echo "Installing MG5aMC_PY8_interface" && \
@@ -134,20 +134,20 @@ RUN cd /usr/local && \
     mkdir -p /code/MG5aMC_PY8_interface && \
     tar -xzvf MG5aMC_PY8_interface_V${MG5aMC_PY8_INTERFACE_VERSION}.tar.gz --directory=MG5aMC_PY8_interface && \
     cd MG5aMC_PY8_interface && \
-    python compile.py /usr/local/ --pythia8_makefile $(find /usr/local/ -type d -name MG5_aMC) && \
-    mkdir -p /usr/local/MG5_aMC/HEPTools/MG5aMC_PY8_interface && \
-    cp *.h /usr/local/MG5_aMC/HEPTools/MG5aMC_PY8_interface/ && \
-    cp *_VERSION_ON_INSTALL /usr/local/MG5_aMC/HEPTools/MG5aMC_PY8_interface/ && \
-    cp MG5aMC_PY8_interface /usr/local/MG5_aMC/HEPTools/MG5aMC_PY8_interface/ && \
+    python compile.py /usr/local/venv/ --pythia8_makefile $(find /usr/local/ -type d -name MG5_aMC) && \
+    mkdir -p /usr/local/venv/MG5_aMC/HEPTools/MG5aMC_PY8_interface && \
+    cp *.h /usr/local/venv/MG5_aMC/HEPTools/MG5aMC_PY8_interface/ && \
+    cp *_VERSION_ON_INSTALL /usr/local/venv/MG5_aMC/HEPTools/MG5aMC_PY8_interface/ && \
+    cp MG5aMC_PY8_interface /usr/local/venv/MG5_aMC/HEPTools/MG5aMC_PY8_interface/ && \
     rm -rf /code
 
 # Change the MadGraph5_aMC@NLO configuration settings
-RUN sed -i '/fastjet =/s/^# //g' /usr/local/MG5_aMC/input/mg5_configuration.txt && \
-    sed -i '/lhapdf_py3 =/s/^# //g' /usr/local/MG5_aMC/input/mg5_configuration.txt && \
-    sed -i 's|# pythia8_path.*|pythia8_path = /usr/local|g' /usr/local/MG5_aMC/input/mg5_configuration.txt && \
-    sed -i '/mg5amc_py8_interface_path =/s/^# //g' /usr/local/MG5_aMC/input/mg5_configuration.txt && \
-    sed -i 's|# eps_viewer.*|eps_viewer = '$(command -v ghostscript)'|g' /usr/local/MG5_aMC/input/mg5_configuration.txt && \
-    sed -i 's|# fortran_compiler.*|fortran_compiler = '$(command -v gfortran)'|g' /usr/local/MG5_aMC/input/mg5_configuration.txt
+RUN sed -i '/fastjet =/s/^# //g' /usr/local/venv/MG5_aMC/input/mg5_configuration.txt && \
+    sed -i '/lhapdf_py3 =/s/^# //g' /usr/local/venv/MG5_aMC/input/mg5_configuration.txt && \
+    sed -i 's|# pythia8_path.*|pythia8_path = /usr/local/venv|g' /usr/local/venv/MG5_aMC/input/mg5_configuration.txt && \
+    sed -i '/mg5amc_py8_interface_path =/s/^# //g' /usr/local/venv/MG5_aMC/input/mg5_configuration.txt && \
+    sed -i 's|# eps_viewer.*|eps_viewer = '$(command -v ghostscript)'|g' /usr/local/venv/MG5_aMC/input/mg5_configuration.txt && \
+    sed -i 's|# fortran_compiler.*|fortran_compiler = '$(command -v gfortran)'|g' /usr/local/venv/MG5_aMC/input/mg5_configuration.txt
 
 # Enable tab completion by uncommenting it from /etc/bash.bashrc
 # The relevant lines are those below the phrase "enable bash completion in interactive shells"
@@ -160,9 +160,9 @@ RUN useradd --shell /bin/bash -m docker && \
    cp /root/.bashrc /home/docker/ && \
    mkdir /home/docker/data && \
    chown -R --from=root docker /home/docker && \
-   chown -R --from=root docker /usr/local/MG5_aMC && \
-   chown -R --from=root docker /usr/local/share && \
-   chown -R --from=503 docker /usr/local/MG5_aMC
+   chown -R --from=root docker /usr/local/venv/MG5_aMC && \
+   chown -R --from=root docker /usr/local/venv/share && \
+   chown -R --from=503 docker /usr/local/venv/MG5_aMC
 
 # Use C.UTF-8 locale to avoid issues with ASCII encoding
 ENV LC_ALL=C.UTF-8
@@ -174,17 +174,17 @@ RUN cp /root/.profile ${HOME}/.profile && \
     cp /root/.bashrc ${HOME}/.bashrc && \
     echo "" >> ${HOME}/.bashrc && \
     echo 'export PATH=${HOME}/.local/bin:$PATH' >> ${HOME}/.bashrc && \
-    echo 'export PATH=/usr/local/MG5_aMC/bin:$PATH' >> ${HOME}/.bashrc && \
+    echo 'export PATH=/usr/local/venv/MG5_aMC/bin:$PATH' >> ${HOME}/.bashrc && \
     python -m pip --no-cache-dir install --upgrade pip setuptools wheel && \
     python -m pip --no-cache-dir install six numpy && \
-    sed -i 's|# f2py_compiler_py3.*|f2py_compiler_py3 = '$(command -v f2py)'|g' /usr/local/MG5_aMC/input/mg5_configuration.txt
+    sed -i 's|# f2py_compiler_py3.*|f2py_compiler_py3 = '$(command -v f2py)'|g' /usr/local/venv/MG5_aMC/input/mg5_configuration.txt
 
 ENV USER docker
 USER docker
-ENV PYTHONPATH=/usr/local/lib:/usr/local/MG5_aMC:$PYTHONPATH
-ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+ENV PYTHONPATH=/usr/local/venv/lib:/usr/local/venv/MG5_aMC:$PYTHONPATH
+ENV LD_LIBRARY_PATH=/usr/local/venv/lib:$LD_LIBRARY_PATH
 ENV PATH=${HOME}/.local/bin:$PATH
-ENV PATH=/usr/local/MG5_aMC/bin:$PATH
+ENV PATH=/usr/local/venv/MG5_aMC/bin:$PATH
 
 ENTRYPOINT ["/bin/bash", "-l", "-c"]
 CMD ["/bin/bash"]

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -35,7 +35,6 @@ RUN apt-get -qq -y update && \
     python -m pip list && \
     printf '\nexport PATH=/usr/local/venv/bin:"${PATH}"\n' >> /root/.bashrc
 
-
 # Install HepMC
 ARG HEPMC_VERSION=2.06.11
 RUN mkdir /code && \
@@ -66,7 +65,7 @@ RUN mkdir /code && \
     cd fastjet-${FASTJET_VERSION} && \
     ./configure --help && \
     export CXX=$(which g++) && \
-    export PYTHON=$(which python) && \
+    export PYTHON_CONFIG=$(find /usr/local/ -iname "python-config.py") && \
     ./configure \
       --prefix=/usr/local/venv \
       --enable-pyext=yes && \

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -35,6 +35,9 @@ RUN apt-get -qq -y update && \
     python -m pip list && \
     printf '\nexport PATH=/usr/local/venv/bin:"${PATH}"\n' >> /root/.bashrc
 
+ENV PYTHONPATH=/usr/local/venv/lib:/usr/local/venv/MG5_aMC:$PYTHONPATH
+ENV LD_LIBRARY_PATH=/usr/local/venv/lib:$LD_LIBRARY_PATH
+
 # Install HepMC
 ARG HEPMC_VERSION=2.06.11
 RUN mkdir /code && \
@@ -65,6 +68,7 @@ RUN mkdir /code && \
     cd fastjet-${FASTJET_VERSION} && \
     ./configure --help && \
     export CXX=$(which g++) && \
+    export PYTHON=$(command -v python) && \
     export PYTHON_CONFIG=$(find /usr/local/ -iname "python-config.py") && \
     ./configure \
       --prefix=/usr/local/venv \
@@ -180,8 +184,6 @@ RUN cp /root/.profile ${HOME}/.profile && \
 
 ENV USER docker
 USER docker
-ENV PYTHONPATH=/usr/local/venv/lib:/usr/local/venv/MG5_aMC:$PYTHONPATH
-ENV LD_LIBRARY_PATH=/usr/local/venv/lib:$LD_LIBRARY_PATH
 ENV PATH=${HOME}/.local/bin:$PATH
 ENV PATH=/usr/local/venv/MG5_aMC/bin:$PATH
 

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -2,7 +2,7 @@ ARG BUILDER_IMAGE=python:3.8-slim-buster
 FROM ${BUILDER_IMAGE} as builder
 
 USER root
-WORKDIR /usr/local
+WORKDIR /
 
 SHELL [ "/bin/bash", "-c" ]
 
@@ -32,6 +32,7 @@ RUN apt-get -qq -y update && \
     python -m venv /usr/local/venv && \
     . /usr/local/venv/bin/activate && \
     python -m pip --no-cache-dir install --upgrade pip setuptools wheel && \
+    python -m pip --no-cache-dir install six numpy && \
     python -m pip list && \
     printf '\nexport PATH=/usr/local/venv/bin:"${PATH}"\n' >> /root/.bashrc
 
@@ -152,7 +153,8 @@ RUN sed -i '/fastjet =/s/^# //g' /usr/local/venv/MG5_aMC/input/mg5_configuration
     sed -i 's|# pythia8_path.*|pythia8_path = /usr/local/venv|g' /usr/local/venv/MG5_aMC/input/mg5_configuration.txt && \
     sed -i '/mg5amc_py8_interface_path =/s/^# //g' /usr/local/venv/MG5_aMC/input/mg5_configuration.txt && \
     sed -i 's|# eps_viewer.*|eps_viewer = '$(command -v ghostscript)'|g' /usr/local/venv/MG5_aMC/input/mg5_configuration.txt && \
-    sed -i 's|# fortran_compiler.*|fortran_compiler = '$(command -v gfortran)'|g' /usr/local/venv/MG5_aMC/input/mg5_configuration.txt
+    sed -i 's|# fortran_compiler.*|fortran_compiler = '$(command -v gfortran)'|g' /usr/local/venv/MG5_aMC/input/mg5_configuration.txt && \
+    sed -i 's|# f2py_compiler_py3.*|f2py_compiler_py3 = '$(command -v f2py)'|g' /usr/local/venv/MG5_aMC/input/mg5_configuration.txt
 
 # Enable tab completion by uncommenting it from /etc/bash.bashrc
 # The relevant lines are those below the phrase "enable bash completion in interactive shells"
@@ -160,13 +162,12 @@ RUN export SED_RANGE="$(($(sed -n '\|enable bash completion in interactive shell
     sed -i -e "${SED_RANGE}"' s/^#//' /etc/bash.bashrc && \
     unset SED_RANGE
 
-# Create user "docker"
+# Create non-root user "docker"
 RUN useradd --shell /bin/bash -m docker && \
    cp /root/.bashrc /home/docker/ && \
    mkdir /home/docker/data && \
    chown -R --from=root docker /home/docker && \
-   chown -R --from=root docker /usr/local/venv/MG5_aMC && \
-   chown -R --from=root docker /usr/local/venv/share && \
+   chown -R --from=root docker /usr/local/venv && \
    chown -R --from=503 docker /usr/local/venv/MG5_aMC
 
 # Use C.UTF-8 locale to avoid issues with ASCII encoding
@@ -175,19 +176,18 @@ ENV LANG=C.UTF-8
 
 ENV HOME /home/docker
 WORKDIR ${HOME}/data
-RUN cp /root/.profile ${HOME}/.profile && \
-    cp /root/.bashrc ${HOME}/.bashrc && \
-    echo "" >> ${HOME}/.bashrc && \
-    echo 'export PATH=${HOME}/.local/bin:$PATH' >> ${HOME}/.bashrc && \
-    echo 'export PATH=/usr/local/venv/MG5_aMC/bin:$PATH' >> ${HOME}/.bashrc && \
-    python -m pip --no-cache-dir install --upgrade pip setuptools wheel && \
-    python -m pip --no-cache-dir install six numpy && \
-    sed -i 's|# f2py_compiler_py3.*|f2py_compiler_py3 = '$(command -v f2py)'|g' /usr/local/venv/MG5_aMC/input/mg5_configuration.txt
 
-ENV USER docker
-USER docker
-ENV PATH=${HOME}/.local/bin:$PATH
+ENV PATH=${HOME}/.local/bin:/root/.local/bin:$PATH
 ENV PATH=/usr/local/venv/MG5_aMC/bin:$PATH
+
+RUN if [ -f /root/.profile ];then cp /root/.profile ${HOME}/.profile;fi && \
+    cp /root/.bashrc ${HOME}/.bashrc && \
+    echo "exit" | mg5_aMC && \
+    rm py.py
+
+# Default user is root to avoid uid write permission problems with volumes
+ENV HOME /root
+WORKDIR ${HOME}/data
 
 ENTRYPOINT ["/bin/bash", "-l", "-c"]
 CMD ["/bin/bash"]

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -6,6 +6,8 @@ WORKDIR /usr/local
 
 SHELL [ "/bin/bash", "-c" ]
 
+# Set PATH to pickup virtualenv by default
+ENV PATH=/usr/local/venv/bin:"${PATH}"
 RUN apt-get -qq -y update && \
     apt-get -qq -y install --no-install-recommends \
       gcc \
@@ -26,7 +28,13 @@ RUN apt-get -qq -y update && \
       git && \
     apt-get -y clean && \
     apt-get -y autoremove && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* && \
+    python -m venv /usr/local/venv && \
+    . /usr/local/venv/bin/activate && \
+    python -m pip --no-cache-dir install --upgrade pip setuptools wheel && \
+    python -m pip list && \
+    printf '\nexport PATH=/usr/local/venv/bin:"${PATH}"\n' >> /root/.bashrc
+
 
 # Install HepMC
 ARG HEPMC_VERSION=2.06.11

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -115,7 +115,9 @@ RUN mkdir /code && \
       --with-fastjet3 \
       --with-python-bin=/usr/local/venv/bin/ \
       --with-python-lib=/usr/local/venv/lib/python${PYTHON_MINOR_VERSION} \
-      --with-python-include=/usr/local/venv/include/python${PYTHON_MINOR_VERSION} && \
+      --with-python-include=/usr/local/venv/include/python${PYTHON_MINOR_VERSION} \
+      --cxx-common="-O2 -m64 -pedantic -W -Wall -Wshadow -fPIC -std=c++17" \
+      --cxx-shared="-shared -std=c++17" && \
     make -j$(($(nproc) - 1)) && \
     make install && \
     rm -rf /code

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -145,7 +145,8 @@ RUN cd /usr/local/venv && \
     cp *.h /usr/local/venv/MG5_aMC/HEPTools/MG5aMC_PY8_interface/ && \
     cp *_VERSION_ON_INSTALL /usr/local/venv/MG5_aMC/HEPTools/MG5aMC_PY8_interface/ && \
     cp MG5aMC_PY8_interface /usr/local/venv/MG5_aMC/HEPTools/MG5aMC_PY8_interface/ && \
-    rm -rf /code
+    rm -rf /code && \
+    printf '\nexport PATH=/usr/local/venv/MG5_aMC/bin:"${PATH}"\n' >> /root/.bashrc
 
 # Change the MadGraph5_aMC@NLO configuration settings
 RUN sed -i '/fastjet =/s/^# //g' /usr/local/venv/MG5_aMC/input/mg5_configuration.txt && \

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -110,12 +110,12 @@ RUN mkdir /code && \
       --cxx=g++ \
       --enable-64bit \
       --with-gzip \
-      --with-hepmc2 \
-      --with-lhapdf6 \
-      --with-fastjet3 \
+      --with-hepmc2=/usr/local/venv \
+      --with-lhapdf6=/usr/local/venv \
+      --with-fastjet3=/usr/local/venv \
       --with-python-bin=/usr/local/venv/bin/ \
       --with-python-lib=/usr/local/venv/lib/python${PYTHON_MINOR_VERSION} \
-      --with-python-include=/usr/local/venv/include/python${PYTHON_MINOR_VERSION} \
+      --with-python-include=/usr/local/include/python${PYTHON_MINOR_VERSION} \
       --cxx-common="-O2 -m64 -pedantic -W -Wall -Wshadow -fPIC -std=c++17" \
       --cxx-shared="-shared -std=c++17" && \
     make -j$(($(nproc) - 1)) && \


### PR DESCRIPTION
```
* Make default user-root to file permission problems for I/O
   - Keep non-root user 'docker' as optional user
* Use install prefix for user installed software of /usr/local/venv
   - Python bindings will pickup the default virtual environment
* Add pytest tests to CI
```