### PR TITLE
feat: Install NLO dependencies through `mg5_aMC install`

### DIFF
--- a/.github/workflows/docker-centos.yml
+++ b/.github/workflows/docker-centos.yml
@@ -113,6 +113,13 @@ jobs:
           scailfin/madgraph5-amc-nlo-centos:sha-${GITHUB_SHA::8}
           "cp -r ${PWD}/tests .; cd tests; bash tests.sh"
 
+      - name: Check NLO process has dependencies
+        run: >-
+          docker run --rm
+          -v $PWD:$PWD
+          scailfin/madgraph5-amc-nlo-centos:sha-${GITHUB_SHA::8}
+          "cp -r ${PWD}/tests/* .; mg5_aMC test_NLO.mg5"
+
       - name: Build and publish to registry
         # every PR will trigger a push event on main, so check the push event is actually coming from main
         if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'scailfin/MadGraph5_aMC-NLO'

--- a/.github/workflows/docker-debian.yml
+++ b/.github/workflows/docker-debian.yml
@@ -113,6 +113,13 @@ jobs:
           scailfin/madgraph5-amc-nlo:sha-${GITHUB_SHA::8}
           "cp -r ${PWD}/tests .; cd tests; bash tests.sh"
 
+      - name: Check NLO process has dependencies
+        run: >-
+          docker run --rm
+          -v $PWD:$PWD
+          scailfin/madgraph5-amc-nlo:sha-${GITHUB_SHA::8}
+          "cp -r ${PWD}/tests/* .; mg5_aMC test_NLO.mg5"
+
       - name: Build and publish to registry
         # every PR will trigger a push event on main, so check the push event is actually coming from main
         if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'scailfin/MadGraph5_aMC-NLO'

--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ The Docker image contains:
 * [PYTHIA](http://home.thep.lu.se/~torbjorn/Pythia.html) `v8.244`
 * [BOOST](https://www.boost.org/doc/libs/1_76_0/more/getting_started/unix-variants.html) `v1.76.0`
 
+Additionally contains MadGraph5 controlled dependencies for NLO processes:
+
+* [CutTools](https://inspirehep.net/literature/768411)
+* [IREGI](https://inspirehep.net/literature/1293923)
+* [Ninja](https://github.com/peraro/ninja)
+* [Collier](https://inspirehep.net/literature/1451658)
+
 ## Installation
 
 - Check the [list of available tags on Docker Hub](https://hub.docker.com/r/scailfin/madgraph5-amc-nlo/tags?page=1) to find the tag you want.

--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -185,6 +185,8 @@ ENV LD_LIBRARY_PATH=/usr/local/venv/lib:$LD_LIBRARY_PATH
 ENV PATH=${HOME}/.local/bin:/root/.local/bin:$PATH
 ENV PATH=/usr/local/venv/MG5_aMC/bin:$PATH
 
+# TODO: Install NLO dependencies independently for greater control
+# Running the NLO process forces install of cuttools and iregi
 RUN if [ -f /root/.profile ];then cp /root/.profile ${HOME}/.profile;fi && \
     cp /root/.bashrc ${HOME}/.bashrc && \
     printf "\nsource scl_source enable devtoolset-8\n" >> ${HOME}/.bash_profile && \

--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -192,6 +192,10 @@ RUN if [ -f /root/.profile ];then cp /root/.profile ${HOME}/.profile;fi && \
     python -m pip --no-cache-dir install six numpy && \
     sed -i 's|# f2py_compiler_py3.*|f2py_compiler_py3 = '$(command -v f2py)'|g' /usr/local/venv/MG5_aMC/input/mg5_configuration.txt && \
     echo "exit" | mg5_aMC && \
+    echo "install oneloop" | mg5_aMC && \
+    echo "install collier" | mg5_aMC && \
+    echo "generate p p > e+ e- aEW=2 aS=0 [QCD]; output test_nlo" | mg5_aMC && \
+    rm -rf test_nlo && \
     rm py.py
 
 # Default user is root to avoid uid write permission problems with volumes

--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -196,6 +196,7 @@ RUN if [ -f /root/.profile ];then cp /root/.profile ${HOME}/.profile;fi && \
     echo "install collier" | mg5_aMC && \
     echo "generate p p > e+ e- aEW=2 aS=0 [QCD]; output test_nlo" | mg5_aMC && \
     rm -rf test_nlo && \
+    rm -rf $(find /usr/local/ -type d -name HEPToolsInstallers) && \
     rm py.py
 
 # Default user is root to avoid uid write permission problems with volumes

--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -192,7 +192,7 @@ RUN if [ -f /root/.profile ];then cp /root/.profile ${HOME}/.profile;fi && \
     python -m pip --no-cache-dir install six numpy && \
     sed -i 's|# f2py_compiler_py3.*|f2py_compiler_py3 = '$(command -v f2py)'|g' /usr/local/venv/MG5_aMC/input/mg5_configuration.txt && \
     echo "exit" | mg5_aMC && \
-    echo "install oneloop" | mg5_aMC && \
+    echo "install ninja" | mg5_aMC && \
     echo "install collier" | mg5_aMC && \
     echo "generate p p > e+ e- aEW=2 aS=0 [QCD]; output test_nlo" | mg5_aMC && \
     rm -rf test_nlo && \

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -181,6 +181,8 @@ WORKDIR ${HOME}/data
 ENV PATH=${HOME}/.local/bin:/root/.local/bin:$PATH
 ENV PATH=/usr/local/venv/MG5_aMC/bin:$PATH
 
+# TODO: Install NLO dependencies independently for greater control
+# Running the NLO process forces install of cuttools and iregi
 RUN if [ -f /root/.profile ];then cp /root/.profile ${HOME}/.profile;fi && \
     cp /root/.bashrc ${HOME}/.bashrc && \
     echo "exit" | mg5_aMC && \

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -184,6 +184,10 @@ ENV PATH=/usr/local/venv/MG5_aMC/bin:$PATH
 RUN if [ -f /root/.profile ];then cp /root/.profile ${HOME}/.profile;fi && \
     cp /root/.bashrc ${HOME}/.bashrc && \
     echo "exit" | mg5_aMC && \
+    echo "install oneloop" | mg5_aMC && \
+    echo "install collier" | mg5_aMC && \
+    echo "generate p p > e+ e- aEW=2 aS=0 [QCD]; output test_nlo" | mg5_aMC && \
+    rm -rf test_nlo && \
     rm py.py
 
 # Default user is root to avoid uid write permission problems with volumes

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -188,6 +188,7 @@ RUN if [ -f /root/.profile ];then cp /root/.profile ${HOME}/.profile;fi && \
     echo "install collier" | mg5_aMC && \
     echo "generate p p > e+ e- aEW=2 aS=0 [QCD]; output test_nlo" | mg5_aMC && \
     rm -rf test_nlo && \
+    rm -rf $(find /usr/local/ -type d -name HEPToolsInstallers) && \
     rm py.py
 
 # Default user is root to avoid uid write permission problems with volumes

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -184,7 +184,7 @@ ENV PATH=/usr/local/venv/MG5_aMC/bin:$PATH
 RUN if [ -f /root/.profile ];then cp /root/.profile ${HOME}/.profile;fi && \
     cp /root/.bashrc ${HOME}/.bashrc && \
     echo "exit" | mg5_aMC && \
-    echo "install oneloop" | mg5_aMC && \
+    echo "install ninja" | mg5_aMC && \
     echo "install collier" | mg5_aMC && \
     echo "generate p p > e+ e- aEW=2 aS=0 [QCD]; output test_nlo" | mg5_aMC && \
     rm -rf test_nlo && \

--- a/tests/test_NLO.mg5
+++ b/tests/test_NLO.mg5
@@ -1,0 +1,2 @@
+generate p p > e+ e- aEW=2 aS=0 [QCD]
+output test_nlo


### PR DESCRIPTION
Resolves #48

Given how frustratingly difficult it is to find and install `cuttools` and `iregi` like normal well behaved software, temporarily cave and use the `mg5_aMC install` command to install NLO recommended dependencies `ninja` and `collier`. Then run a NLO process to automatically pick up the NLO dependencies `cuttools` and `iregi`.

Run the same process in CI as a test to ensure that things were installed as expected.

```
* Install NLO recommended dependencies ninja and collier with `mg5_aMC install`
* Install NLO dependencies cuttools and iregi automatically by running an NLO process
* Add TODO to find a way to install globally with better control
* Add test in CI to ensure all dependencies are installed
* Add list of installed NLO dependencies to README
```