### PR TITLE
feat: Update to mg5_aMC v3.4.1, PYTHIA v8.306

### DIFF
--- a/.github/workflows/docker-centos.yml
+++ b/.github/workflows/docker-centos.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           DOCKER_IMAGE=scailfin/madgraph5-amc-nlo-centos
           VERSION=latest
-          MADGRAPH_VERSION=mg5_amc3.4.0
+          MADGRAPH_VERSION=mg5_amc3.4.1
           REPO_NAME=${{github.repository}}
           REPO_NAME_LOWERCASE="${REPO_NAME,,}"
           if [[ $GITHUB_REF == refs/tags/* ]]; then

--- a/.github/workflows/docker-debian.yml
+++ b/.github/workflows/docker-debian.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           DOCKER_IMAGE=scailfin/madgraph5-amc-nlo
           VERSION=latest
-          MADGRAPH_VERSION=mg5_amc3.4.0
+          MADGRAPH_VERSION=mg5_amc3.4.1
           REPO_NAME=${{github.repository}}
           REPO_NAME_LOWERCASE="${REPO_NAME,,}"
           if [[ $GITHUB_REF == refs/tags/* ]]; then

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ image:
 	--build-arg HEPMC_VERSION=2.06.11 \
 	--build-arg FASTJET_VERSION=3.3.4 \
 	--build-arg LHAPDF_VERSION=6.5.1 \
-	--build-arg PYTHIA_VERSION=8307 \
+	--build-arg PYTHIA_VERSION=8306 \
 	--build-arg MG_VERSION=3.4.1 \
 	-t scailfin/madgraph5-amc-nlo:latest \
 	-t scailfin/madgraph5-amc-nlo:3.4.1 \
@@ -24,7 +24,7 @@ test:
 	--build-arg HEPMC_VERSION=2.06.11 \
 	--build-arg FASTJET_VERSION=3.3.4 \
 	--build-arg LHAPDF_VERSION=6.5.1 \
-	--build-arg PYTHIA_VERSION=8307 \
+	--build-arg PYTHIA_VERSION=8306 \
 	--build-arg MG_VERSION=3.4.1 \
 	-t scailfin/madgraph5-amc-nlo:debug-local
 
@@ -34,6 +34,6 @@ test-centos:
 	--build-arg HEPMC_VERSION=2.06.11 \
 	--build-arg FASTJET_VERSION=3.3.4 \
 	--build-arg LHAPDF_VERSION=6.5.1 \
-	--build-arg PYTHIA_VERSION=8307 \
+	--build-arg PYTHIA_VERSION=8306 \
 	--build-arg MG_VERSION=3.4.1 \
 	-t scailfin/madgraph5-amc-nlo-centos:debug-local

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ image:
 	--build-arg HEPMC_VERSION=2.06.11 \
 	--build-arg FASTJET_VERSION=3.3.4 \
 	--build-arg LHAPDF_VERSION=6.5.1 \
-	--build-arg PYTHIA_VERSION=8244 \
+	--build-arg PYTHIA_VERSION=8245 \
 	--build-arg MG_VERSION=3.4.0 \
 	-t scailfin/madgraph5-amc-nlo:latest \
 	-t scailfin/madgraph5-amc-nlo:3.4.0 \
@@ -24,7 +24,7 @@ test:
 	--build-arg HEPMC_VERSION=2.06.11 \
 	--build-arg FASTJET_VERSION=3.3.4 \
 	--build-arg LHAPDF_VERSION=6.5.1 \
-	--build-arg PYTHIA_VERSION=8244 \
+	--build-arg PYTHIA_VERSION=8245 \
 	--build-arg MG_VERSION=3.4.0 \
 	-t scailfin/madgraph5-amc-nlo:debug-local
 

--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,9 @@ image:
 	--build-arg FASTJET_VERSION=3.3.4 \
 	--build-arg LHAPDF_VERSION=6.5.1 \
 	--build-arg PYTHIA_VERSION=8307 \
-	--build-arg MG_VERSION=3.4.0 \
+	--build-arg MG_VERSION=3.4.1 \
 	-t scailfin/madgraph5-amc-nlo:latest \
-	-t scailfin/madgraph5-amc-nlo:3.4.0 \
+	-t scailfin/madgraph5-amc-nlo:3.4.1 \
 	--compress
 
 test:
@@ -25,7 +25,7 @@ test:
 	--build-arg FASTJET_VERSION=3.3.4 \
 	--build-arg LHAPDF_VERSION=6.5.1 \
 	--build-arg PYTHIA_VERSION=8307 \
-	--build-arg MG_VERSION=3.4.0 \
+	--build-arg MG_VERSION=3.4.1 \
 	-t scailfin/madgraph5-amc-nlo:debug-local
 
 test-centos:
@@ -35,5 +35,5 @@ test-centos:
 	--build-arg FASTJET_VERSION=3.3.4 \
 	--build-arg LHAPDF_VERSION=6.5.1 \
 	--build-arg PYTHIA_VERSION=8307 \
-	--build-arg MG_VERSION=3.4.0 \
+	--build-arg MG_VERSION=3.4.1 \
 	-t scailfin/madgraph5-amc-nlo-centos:debug-local

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,6 @@ test-centos:
 	--build-arg HEPMC_VERSION=2.06.11 \
 	--build-arg FASTJET_VERSION=3.3.4 \
 	--build-arg LHAPDF_VERSION=6.5.1 \
-	--build-arg PYTHIA_VERSION=8243 \
+	--build-arg PYTHIA_VERSION=8245 \
 	--build-arg MG_VERSION=3.4.0 \
 	-t scailfin/madgraph5-amc-nlo-centos:debug-local

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ image:
 	--build-arg HEPMC_VERSION=2.06.11 \
 	--build-arg FASTJET_VERSION=3.3.4 \
 	--build-arg LHAPDF_VERSION=6.5.1 \
-	--build-arg PYTHIA_VERSION=8245 \
+	--build-arg PYTHIA_VERSION=8307 \
 	--build-arg MG_VERSION=3.4.0 \
 	-t scailfin/madgraph5-amc-nlo:latest \
 	-t scailfin/madgraph5-amc-nlo:3.4.0 \
@@ -24,7 +24,7 @@ test:
 	--build-arg HEPMC_VERSION=2.06.11 \
 	--build-arg FASTJET_VERSION=3.3.4 \
 	--build-arg LHAPDF_VERSION=6.5.1 \
-	--build-arg PYTHIA_VERSION=8245 \
+	--build-arg PYTHIA_VERSION=8307 \
 	--build-arg MG_VERSION=3.4.0 \
 	-t scailfin/madgraph5-amc-nlo:debug-local
 
@@ -34,6 +34,6 @@ test-centos:
 	--build-arg HEPMC_VERSION=2.06.11 \
 	--build-arg FASTJET_VERSION=3.3.4 \
 	--build-arg LHAPDF_VERSION=6.5.1 \
-	--build-arg PYTHIA_VERSION=8245 \
+	--build-arg PYTHIA_VERSION=8307 \
 	--build-arg MG_VERSION=3.4.0 \
 	-t scailfin/madgraph5-amc-nlo-centos:debug-local

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The Docker image contains:
 * [HepMC2](http://hepmc.web.cern.ch/hepmc/) `v2.06.11`
 * [LHAPDF](https://lhapdf.hepforge.org/) `v6.5.1`
 * [FastJet](http://fastjet.fr/) `v3.3.4`
-* [PYTHIA](https://pythia.org/) `v8.245`
+* [PYTHIA](https://pythia.org/) `v8.307`
 * [BOOST](https://www.boost.org/doc/libs/1_76_0/more/getting_started/unix-variants.html) `v1.76.0`
 
 Additionally contains MadGraph5 controlled dependencies for NLO processes:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The Docker image contains:
 * [HepMC2](http://hepmc.web.cern.ch/hepmc/) `v2.06.11`
 * [LHAPDF](https://lhapdf.hepforge.org/) `v6.5.1`
 * [FastJet](http://fastjet.fr/) `v3.3.4`
-* [PYTHIA](https://pythia.org/) `v8.307`
+* [PYTHIA](https://pythia.org/) `v8.306`
 * [BOOST](https://www.boost.org/doc/libs/1_76_0/more/getting_started/unix-variants.html) `v1.76.0`
 
 Additionally contains MadGraph5 controlled dependencies for NLO processes:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Docker image for Python 3 compliant [MadGraph5_aMC@NLO](https://launchpad.net/mg
 
 The Docker image contains:
 
-* [MadGraph5_aMC@NLO](https://launchpad.net/mg5amcnlo) `v3.4.0`
+* [MadGraph5_aMC@NLO](https://launchpad.net/mg5amcnlo) `v3.4.1`
 * Python 3.9
 * [HepMC2](http://hepmc.web.cern.ch/hepmc/) `v2.06.11`
 * [LHAPDF](https://lhapdf.hepforge.org/) `v6.5.1`
@@ -31,7 +31,7 @@ Additionally contains MadGraph5 controlled dependencies for NLO processes:
 - Use `docker pull` to pull down the image corresponding to the tag. For example:
 
 ```
-docker pull scailfin/madgraph5-amc-nlo:mg5_amc3.4.0
+docker pull scailfin/madgraph5-amc-nlo:mg5_amc3.4.1
 ```
 
 ## Use
@@ -39,7 +39,7 @@ docker pull scailfin/madgraph5-amc-nlo:mg5_amc3.4.0
 MadGraph5_aMC@NLO is in `PATH` when the container starts
 
 ```
-docker run --rm scailfin/madgraph5-amc-nlo:mg5_amc3.4.0 "mg5_aMC --help"
+docker run --rm scailfin/madgraph5-amc-nlo:mg5_amc3.4.1 "mg5_aMC --help"
 Usage: mg5_aMC [options] [FILE]
 
 Options:
@@ -63,7 +63,7 @@ so you should be able to make any directory inside the container a working direc
 If you run the image as an interactive container with your local path bind mounted to the working directory
 
 ```shell
-docker run --rm -ti -v $PWD:$PWD -w $PWD scailfin/madgraph5-amc-nlo:mg5_amc3.4.0
+docker run --rm -ti -v $PWD:$PWD -w $PWD scailfin/madgraph5-amc-nlo:mg5_amc3.4.1
 ```
 
 output from your work in that directory in the interactive session will be preserved when the container exists.
@@ -71,7 +71,7 @@ output from your work in that directory in the interactive session will be prese
 The container can be used a runtime application by passing in a MadGraph program as a `.mg5` file to the `mg5_aMC` CLI API
 
 ```shell
-docker run --rm -v $PWD:$PWD -w $PWD scailfin/madgraph5-amc-nlo:mg5_amc3.4.0 "mg5_aMC file-name.mg5"
+docker run --rm -v $PWD:$PWD -w $PWD scailfin/madgraph5-amc-nlo:mg5_amc3.4.1 "mg5_aMC file-name.mg5"
 ```
 
 For further examples see the tests.
@@ -81,7 +81,7 @@ For further examples see the tests.
 As an example test you can run the [top mass scan example](https://answers.launchpad.net/mg5amcnlo/+faq/2186) in the `tests` directory inside the Docker container by running the following from the top level directory of this repository
 
 ```shell
-docker run --rm -v $PWD:$PWD scailfin/madgraph5-amc-nlo:mg5_amc3.4.0 "cd ${PWD}/tests; bash tests.sh"
+docker run --rm -v $PWD:$PWD scailfin/madgraph5-amc-nlo:mg5_amc3.4.1 "cd ${PWD}/tests; bash tests.sh"
 ```
 
 or run the test runner

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The Docker image contains:
 * [HepMC2](http://hepmc.web.cern.ch/hepmc/) `v2.06.11`
 * [LHAPDF](https://lhapdf.hepforge.org/) `v6.5.1`
 * [FastJet](http://fastjet.fr/) `v3.3.4`
-* [PYTHIA](http://home.thep.lu.se/~torbjorn/Pythia.html) `v8.244`
+* [PYTHIA](http://home.thep.lu.se/~torbjorn/Pythia.html) `v8.245`
 * [BOOST](https://www.boost.org/doc/libs/1_76_0/more/getting_started/unix-variants.html) `v1.76.0`
 
 Additionally contains MadGraph5 controlled dependencies for NLO processes:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The Docker image contains:
 * [HepMC2](http://hepmc.web.cern.ch/hepmc/) `v2.06.11`
 * [LHAPDF](https://lhapdf.hepforge.org/) `v6.5.1`
 * [FastJet](http://fastjet.fr/) `v3.3.4`
-* [PYTHIA](http://home.thep.lu.se/~torbjorn/Pythia.html) `v8.245`
+* [PYTHIA](https://pythia.org/) `v8.245`
 * [BOOST](https://www.boost.org/doc/libs/1_76_0/more/getting_started/unix-variants.html) `v1.76.0`
 
 Additionally contains MadGraph5 controlled dependencies for NLO processes:

--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -85,7 +85,7 @@ RUN mkdir /code && \
     rm -rf /code
 
 # Install PYTHIA
-ARG PYTHIA_VERSION=8307
+ARG PYTHIA_VERSION=8306
 # PYTHON_VERSION already exists in the base image
 # CentOS 7 gcc v4.8.5 is old enough need to specify -std=c++11
 RUN mkdir /code && \

--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -85,7 +85,7 @@ RUN mkdir /code && \
     rm -rf /code
 
 # Install PYTHIA
-ARG PYTHIA_VERSION=8244
+ARG PYTHIA_VERSION=8245
 # PYTHON_VERSION already exists in the base image
 # CentOS 7 gcc v4.8.5 is old enough need to specify -std=c++11
 RUN mkdir /code && \

--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -133,7 +133,7 @@ RUN mkdir -p /code && \
     rm -rf /code
 
 # Install MadGraph5_aMC@NLO for Python 3 and PYTHIA 8 interface
-ARG MG_VERSION=3.4.0
+ARG MG_VERSION=3.4.1
 # Versions viewable on Illinois mirror
 # http://madgraph.physics.illinois.edu/Downloads/MG5aMC_PY8_interface/
 ARG MG5aMC_PY8_INTERFACE_VERSION=1.3

--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -136,7 +136,7 @@ RUN mkdir -p /code && \
 ARG MG_VERSION=3.4.0
 # Versions viewable on Illinois mirror
 # http://madgraph.physics.illinois.edu/Downloads/MG5aMC_PY8_interface/
-ARG MG5aMC_PY8_INTERFACE_VERSION=1.2
+ARG MG5aMC_PY8_INTERFACE_VERSION=1.3
 RUN cd /usr/local/venv && \
     wget --quiet https://launchpad.net/mg5amcnlo/3.0/3.4.x/+download/MG5_aMC_v${MG_VERSION}.tar.gz && \
     mkdir -p /usr/local/venv/MG5_aMC && \

--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -85,7 +85,7 @@ RUN mkdir /code && \
     rm -rf /code
 
 # Install PYTHIA
-ARG PYTHIA_VERSION=8245
+ARG PYTHIA_VERSION=8307
 # PYTHON_VERSION already exists in the base image
 # CentOS 7 gcc v4.8.5 is old enough need to specify -std=c++11
 RUN mkdir /code && \

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -127,7 +127,7 @@ RUN mkdir /code && \
 ARG MG_VERSION=3.4.0
 # Versions viewable on Illinois mirror
 # http://madgraph.physics.illinois.edu/Downloads/MG5aMC_PY8_interface/
-ARG MG5aMC_PY8_INTERFACE_VERSION=1.2
+ARG MG5aMC_PY8_INTERFACE_VERSION=1.3
 RUN cd /usr/local/venv && \
     wget --quiet https://launchpad.net/mg5amcnlo/3.0/3.4.x/+download/MG5_aMC_v${MG_VERSION}.tar.gz && \
     mkdir -p /usr/local/venv/MG5_aMC && \

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -124,7 +124,7 @@ RUN mkdir /code && \
     rm -rf /code
 
 # Install MadGraph5_aMC@NLO for Python 3 and PYTHIA 8 interface
-ARG MG_VERSION=3.4.0
+ARG MG_VERSION=3.4.1
 # Versions viewable on Illinois mirror
 # http://madgraph.physics.illinois.edu/Downloads/MG5aMC_PY8_interface/
 ARG MG5aMC_PY8_INTERFACE_VERSION=1.3

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -96,7 +96,7 @@ RUN mkdir /code && \
     rm -rf /code
 
 # Install PYTHIA
-ARG PYTHIA_VERSION=8307
+ARG PYTHIA_VERSION=8306
 # PYTHON_VERSION already exists in the base image
 RUN mkdir /code && \
     cd /code && \

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -96,7 +96,7 @@ RUN mkdir /code && \
     rm -rf /code
 
 # Install PYTHIA
-ARG PYTHIA_VERSION=8244
+ARG PYTHIA_VERSION=8245
 # PYTHON_VERSION already exists in the base image
 RUN mkdir /code && \
     cd /code && \

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -96,7 +96,7 @@ RUN mkdir /code && \
     rm -rf /code
 
 # Install PYTHIA
-ARG PYTHIA_VERSION=8245
+ARG PYTHIA_VERSION=8307
 # PYTHON_VERSION already exists in the base image
 RUN mkdir /code && \
     cd /code && \

--- a/test_runner.sh
+++ b/test_runner.sh
@@ -4,7 +4,7 @@ set -e
 set -u
 set -o pipefail
 
-test_image="scailfin/madgraph5-amc-nlo:mg5_amc3.4.0"
+test_image="scailfin/madgraph5-amc-nlo:mg5_amc3.4.1"
 
 docker pull "${test_image}"
 docker run \


### PR DESCRIPTION
Update to MadGraph5_aMC-NLO `v3.4.1` and PYTHIA to `v8.306`. `MG5aMC_PY8_INTERFACE_VERSION` `v1.3` only works with PYTHIA `v83xx` and won't build with `v8.307`.

```
* Update to MadGraph5_aMC-NLO v3.4.1, PYTHIA to v8.306, and MG5aMC_PY8_INTERFACE_VERSION v1.3.
  MG5aMC_PY8_INTERFACE_VERSION v1.2 has been removed and MadGraph5_aMC-NLO v3.4.1+ is needed
  for compilation with MG5aMC_PY8_INTERFACE_VERSION v1.3, which also requires
  PYTHIA v8.306 (v8.307 currently introduces a build error).
   - c.f. https://launchpad.net/mg5amcnlo/3.0/3.4.x/+download/MG5_aMC_v3.4.1.tar.gz
   - c.f. https://pythia.org/download/pythia83/pythia8307.tgz
* Update PYTHIA website URL.
```