### PR TITLE
feat: Update base image to OS debian bullseye

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all: image
 image:
 	docker build . \
 	-f docker/debian/Dockerfile \
-	--build-arg BUILDER_IMAGE=python:3.8-slim-buster \
+	--build-arg BUILDER_IMAGE=python:3.8-slim-bullseye \
 	--build-arg HEPMC_VERSION=2.06.11 \
 	--build-arg FASTJET_VERSION=3.3.4 \
 	--build-arg LHAPDF_VERSION=6.3.0 \
@@ -18,7 +18,7 @@ image:
 test:
 	docker build . \
 	-f docker/debian/Dockerfile \
-	--build-arg BUILDER_IMAGE=python:3.8-slim-buster \
+	--build-arg BUILDER_IMAGE=python:3.8-slim-bullseye \
 	--build-arg HEPMC_VERSION=2.06.11 \
 	--build-arg FASTJET_VERSION=3.3.4 \
 	--build-arg LHAPDF_VERSION=6.3.0 \

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ default: image
 all: image
 
 image:
+	docker pull python:3.8-slim-bullseye
 	docker build . \
 	-f docker/debian/Dockerfile \
 	--build-arg BUILDER_IMAGE=python:3.8-slim-bullseye \
@@ -16,6 +17,7 @@ image:
 	--compress
 
 test:
+	docker pull python:3.8-slim-bullseye
 	docker build . \
 	-f docker/debian/Dockerfile \
 	--build-arg BUILDER_IMAGE=python:3.8-slim-bullseye \

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILDER_IMAGE=python:3.8-slim-buster
+ARG BUILDER_IMAGE=python:3.8-slim-bullseye
 FROM ${BUILDER_IMAGE} as builder
 
 USER root

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get -qq -y update && \
       make \
       cmake \
       vim \
-      zlibc \
+      zlib1g \
       zlib1g-dev \
       libbz2-dev \
       rsync \


### PR DESCRIPTION
```
* Update Debian base image to python:3.8-slim-bullseye
* Update apt-get packages to debian bullseye supported packages
   - `zlibc` -> `zlib1g`
* Add docker pull of base image to Makefile
```