### PR TITLE
fix: Use first 3 characters to get Python minor version

### DIFF
--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -94,7 +94,7 @@ RUN mkdir /code && \
     tar xvfz pythia${PYTHIA_VERSION}.tgz && \
     cd pythia${PYTHIA_VERSION} && \
     ./configure --help && \
-    export PYTHON_MINOR_VERSION=${PYTHON_VERSION::-3} && \
+    export PYTHON_MINOR_VERSION=${PYTHON_VERSION::3} && \
     ./configure \
       --prefix=/usr/local/venv \
       --arch=Linux \

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -104,7 +104,7 @@ RUN mkdir /code && \
     tar xvfz pythia${PYTHIA_VERSION}.tgz && \
     cd pythia${PYTHIA_VERSION} && \
     ./configure --help && \
-    export PYTHON_MINOR_VERSION=${PYTHON_VERSION::-3} && \
+    export PYTHON_MINOR_VERSION=${PYTHON_VERSION::3} && \
     ./configure \
       --prefix=/usr/local/venv \
       --arch=Linux \


### PR DESCRIPTION
Using `${PYTHON_VERSION::-3}` to get the minor version of the Python runtime will cause a bug if the patch version isn't `x.y.10` or later so use the first three characters of `PYTHON_VERSION`, `${PYTHON_VERSION::3}`, instead which should always work.

Example:

`PYTHON_VERSION=3.8.10`:
* `${PYTHON_VERSION::-3}` is `3.8`
* `${PYTHON_VERSION::3}` is `3.8`

`PYTHON_VERSION=3.8.9`:
* `${PYTHON_VERSION::-3}` is `3.`
* `${PYTHON_VERSION::3}` is `3.8`

```
Using ${PYTHON_VERSION::-3} to get the minor version of the Python
runtime will cause a bug if the patch version isn't x.y.10 or later
so use the first three characters of PYTHON_VERSION,
${PYTHON_VERSION::3}, instead which should always work.

Example:

PYTHON_VERSION=3.8.10:
* ${PYTHON_VERSION::-3} is 3.8
* ${PYTHON_VERSION::3} is 3.8

PYTHON_VERSION=3.8.9:
* ${PYTHON_VERSION::-3} is 3.
* ${PYTHON_VERSION::3} is 3.8
```