### PR TITLE
feat: Update to mg5_aMC v3.3.2

### DIFF
--- a/.github/workflows/docker-centos.yml
+++ b/.github/workflows/docker-centos.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           DOCKER_IMAGE=scailfin/madgraph5-amc-nlo-centos
           VERSION=latest
-          MADGRAPH_VERSION=mg5_amc3.3.1
+          MADGRAPH_VERSION=mg5_amc3.3.2
           REPO_NAME=${{github.repository}}
           REPO_NAME_LOWERCASE="${REPO_NAME,,}"
           if [[ $GITHUB_REF == refs/tags/* ]]; then

--- a/.github/workflows/docker-debian.yml
+++ b/.github/workflows/docker-debian.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           DOCKER_IMAGE=scailfin/madgraph5-amc-nlo
           VERSION=latest
-          MADGRAPH_VERSION=mg5_amc3.3.1
+          MADGRAPH_VERSION=mg5_amc3.3.2
           REPO_NAME=${{github.repository}}
           REPO_NAME_LOWERCASE="${REPO_NAME,,}"
           if [[ $GITHUB_REF == refs/tags/* ]]; then

--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,9 @@ image:
 	--build-arg FASTJET_VERSION=3.3.4 \
 	--build-arg LHAPDF_VERSION=6.3.0 \
 	--build-arg PYTHIA_VERSION=8244 \
-	--build-arg MG_VERSION=3.3.1 \
+	--build-arg MG_VERSION=3.3.2 \
 	-t scailfin/madgraph5-amc-nlo:latest \
-	-t scailfin/madgraph5-amc-nlo:3.3.1 \
+	-t scailfin/madgraph5-amc-nlo:3.3.2 \
 	--compress
 
 test:
@@ -25,7 +25,7 @@ test:
 	--build-arg FASTJET_VERSION=3.3.4 \
 	--build-arg LHAPDF_VERSION=6.3.0 \
 	--build-arg PYTHIA_VERSION=8244 \
-	--build-arg MG_VERSION=3.3.1 \
+	--build-arg MG_VERSION=3.3.2 \
 	-t scailfin/madgraph5-amc-nlo:debug-local
 
 test-centos:
@@ -35,5 +35,5 @@ test-centos:
 	--build-arg FASTJET_VERSION=3.3.4 \
 	--build-arg LHAPDF_VERSION=6.3.0 \
 	--build-arg PYTHIA_VERSION=8243 \
-	--build-arg MG_VERSION=3.3.1 \
+	--build-arg MG_VERSION=3.3.2 \
 	-t scailfin/madgraph5-amc-nlo-centos:debug-local

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Docker image for Python 3 compliant [MadGraph5_aMC@NLO](https://launchpad.net/mg
 
 The Docker image contains:
 
-* [MadGraph5_aMC@NLO](https://launchpad.net/mg5amcnlo) `v3.3.1`
+* [MadGraph5_aMC@NLO](https://launchpad.net/mg5amcnlo) `v3.3.2`
 * Python 3.9
 * [HepMC2](http://hepmc.web.cern.ch/hepmc/) `v2.06.11`
 * [LHAPDF](https://lhapdf.hepforge.org/) `v6.3.0`
@@ -31,7 +31,7 @@ Additionally contains MadGraph5 controlled dependencies for NLO processes:
 - Use `docker pull` to pull down the image corresponding to the tag. For example:
 
 ```
-docker pull scailfin/madgraph5-amc-nlo:mg5_amc3.3.1
+docker pull scailfin/madgraph5-amc-nlo:mg5_amc3.3.2
 ```
 
 ## Use
@@ -39,7 +39,7 @@ docker pull scailfin/madgraph5-amc-nlo:mg5_amc3.3.1
 MadGraph5_aMC@NLO is in `PATH` when the container starts
 
 ```
-docker run --rm scailfin/madgraph5-amc-nlo:mg5_amc3.3.1 "mg5_aMC --help"
+docker run --rm scailfin/madgraph5-amc-nlo:mg5_amc3.3.2 "mg5_aMC --help"
 Usage: mg5_aMC [options] [FILE]
 
 Options:
@@ -63,7 +63,7 @@ so you should be able to make any directory inside the container a working direc
 If you run the image as an interactive container with your local path bind mounted to the working directory
 
 ```shell
-docker run --rm -ti -v $PWD:$PWD -w $PWD scailfin/madgraph5-amc-nlo:mg5_amc3.3.1
+docker run --rm -ti -v $PWD:$PWD -w $PWD scailfin/madgraph5-amc-nlo:mg5_amc3.3.2
 ```
 
 output from your work in that directory in the interactive session will be preserved when the container exists.
@@ -71,7 +71,7 @@ output from your work in that directory in the interactive session will be prese
 The container can be used a runtime application by passing in a MadGraph program as a `.mg5` file to the `mg5_aMC` CLI API
 
 ```shell
-docker run --rm -v $PWD:$PWD -w $PWD scailfin/madgraph5-amc-nlo:mg5_amc3.3.1 "mg5_aMC file-name.mg5"
+docker run --rm -v $PWD:$PWD -w $PWD scailfin/madgraph5-amc-nlo:mg5_amc3.3.2 "mg5_aMC file-name.mg5"
 ```
 
 For further examples see the tests.
@@ -81,7 +81,7 @@ For further examples see the tests.
 As an example test you can run the [top mass scan example](https://answers.launchpad.net/mg5amcnlo/+faq/2186) in the `tests` directory inside the Docker container by running the following from the top level directory of this repository
 
 ```shell
-docker run --rm -v $PWD:$PWD scailfin/madgraph5-amc-nlo:mg5_amc3.3.1 "cd ${PWD}/tests; bash tests.sh"
+docker run --rm -v $PWD:$PWD scailfin/madgraph5-amc-nlo:mg5_amc3.3.2 "cd ${PWD}/tests; bash tests.sh"
 ```
 
 or run the test runner

--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -133,7 +133,7 @@ RUN mkdir -p /code && \
     rm -rf /code
 
 # Install MadGraph5_aMC@NLO for Python 3 and PYTHIA 8 interface
-ARG MG_VERSION=3.3.1
+ARG MG_VERSION=3.3.2
 # Versions viewable on Illinois mirror
 # http://madgraph.physics.illinois.edu/Downloads/MG5aMC_PY8_interface/
 ARG MG5aMC_PY8_INTERFACE_VERSION=1.2

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -124,7 +124,7 @@ RUN mkdir /code && \
     rm -rf /code
 
 # Install MadGraph5_aMC@NLO for Python 3 and PYTHIA 8 interface
-ARG MG_VERSION=3.3.1
+ARG MG_VERSION=3.3.2
 # Versions viewable on Illinois mirror
 # http://madgraph.physics.illinois.edu/Downloads/MG5aMC_PY8_interface/
 ARG MG5aMC_PY8_INTERFACE_VERSION=1.2

--- a/test_runner.sh
+++ b/test_runner.sh
@@ -4,7 +4,7 @@ set -e
 set -u
 set -o pipefail
 
-test_image="scailfin/madgraph5-amc-nlo:mg5_amc3.3.1"
+test_image="scailfin/madgraph5-amc-nlo:mg5_amc3.3.2"
 
 docker pull "${test_image}"
 docker run \


### PR DESCRIPTION
Update to release [`v3.3.2` of MadGraph5_aMC-NLO](https://launchpad.net/mg5amcnlo/3.0/3.3.x).

```
* Update to MadGraph5_aMC-NLO v3.3.2
   - c.f. https://launchpad.net/mg5amcnlo/3.0/3.3.x/+download/MG5_aMC_v3.3.2.tar.gz
```