### PR TITLE
feat: Update LHAPDF to v6.5.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ image:
 	--build-arg BUILDER_IMAGE=python:3.9-slim-bullseye \
 	--build-arg HEPMC_VERSION=2.06.11 \
 	--build-arg FASTJET_VERSION=3.3.4 \
-	--build-arg LHAPDF_VERSION=6.5.1 \
+	--build-arg LHAPDF_VERSION=6.5.3 \
 	--build-arg PYTHIA_VERSION=8306 \
 	--build-arg MG_VERSION=3.4.1 \
 	-t scailfin/madgraph5-amc-nlo:latest \
@@ -23,7 +23,7 @@ test:
 	--build-arg BUILDER_IMAGE=python:3.9-slim-bullseye \
 	--build-arg HEPMC_VERSION=2.06.11 \
 	--build-arg FASTJET_VERSION=3.3.4 \
-	--build-arg LHAPDF_VERSION=6.5.1 \
+	--build-arg LHAPDF_VERSION=6.5.3 \
 	--build-arg PYTHIA_VERSION=8306 \
 	--build-arg MG_VERSION=3.4.1 \
 	-t scailfin/madgraph5-amc-nlo:debug-local
@@ -33,7 +33,7 @@ test-centos:
 	-f docker/centos/Dockerfile \
 	--build-arg HEPMC_VERSION=2.06.11 \
 	--build-arg FASTJET_VERSION=3.3.4 \
-	--build-arg LHAPDF_VERSION=6.5.1 \
+	--build-arg LHAPDF_VERSION=6.5.3 \
 	--build-arg PYTHIA_VERSION=8306 \
 	--build-arg MG_VERSION=3.4.1 \
 	-t scailfin/madgraph5-amc-nlo-centos:debug-local

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The Docker image contains:
 * [MadGraph5_aMC@NLO](https://launchpad.net/mg5amcnlo) `v3.4.1`
 * Python 3.9
 * [HepMC2](http://hepmc.web.cern.ch/hepmc/) `v2.06.11`
-* [LHAPDF](https://lhapdf.hepforge.org/) `v6.5.1`
+* [LHAPDF](https://lhapdf.hepforge.org/) `v6.5.3`
 * [FastJet](http://fastjet.fr/) `v3.3.4`
 * [PYTHIA](https://pythia.org/) `v8.306`
 * [BOOST](https://www.boost.org/doc/libs/1_76_0/more/getting_started/unix-variants.html) `v1.76.0`

--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -69,7 +69,7 @@ RUN mkdir /code && \
     rm -rf /code
 
 # Install LHAPDF
-ARG LHAPDF_VERSION=6.5.1
+ARG LHAPDF_VERSION=6.5.3
 RUN mkdir /code && \
     cd /code && \
     wget https://lhapdf.hepforge.org/downloads/?f=LHAPDF-${LHAPDF_VERSION}.tar.gz -O LHAPDF-${LHAPDF_VERSION}.tar.gz && \

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -80,7 +80,7 @@ RUN mkdir /code && \
     rm -rf /code
 
 # Install LHAPDF
-ARG LHAPDF_VERSION=6.5.1
+ARG LHAPDF_VERSION=6.5.3
 RUN mkdir /code && \
     cd /code && \
     wget https://lhapdf.hepforge.org/downloads/?f=LHAPDF-${LHAPDF_VERSION}.tar.gz -O LHAPDF-${LHAPDF_VERSION}.tar.gz && \


### PR DESCRIPTION
* c.f. https://lhapdf.hepforge.org/downloads/?f=LHAPDF-6.5.3.tar.gz