### PR TITLE
fix: Remove python3-dev from apt-get dependencies

### DIFF
--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -94,7 +94,7 @@ RUN mkdir /code && \
     tar xvfz pythia${PYTHIA_VERSION}.tgz && \
     cd pythia${PYTHIA_VERSION} && \
     ./configure --help && \
-    export PYTHON_MINOR_VERSION=${PYTHON_VERSION::3} && \
+    export PYTHON_MINOR_VERSION="${PYTHON_VERSION%.*}" && \
     ./configure \
       --prefix=/usr/local/venv \
       --arch=Linux \

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -103,7 +103,7 @@ RUN mkdir /code && \
     tar xvfz pythia${PYTHIA_VERSION}.tgz && \
     cd pythia${PYTHIA_VERSION} && \
     ./configure --help && \
-    export PYTHON_MINOR_VERSION=${PYTHON_VERSION::3} && \
+    export PYTHON_MINOR_VERSION="${PYTHON_VERSION%.*}" && \
     ./configure \
       --prefix=/usr/local/venv \
       --arch=Linux \

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -21,7 +21,6 @@ RUN apt-get -qq -y update && \
       libbz2-dev \
       rsync \
       bash-completion \
-      python3-dev \
       wget \
       ghostscript \
       bc \


### PR DESCRIPTION
* The python Docker images already contain the Python.h header files and having multiple can potentially result in conflicts during builds.

```
* The python Docker images already contain the Python.h header files
  and having multiple can potentially result in conflicts during builds.
* Use ${PYTHON_VERSION%.*} to properly get Python minor version info.
```