### PR TITLE
feat: Update Python to 3.10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@ default: image
 all: image
 
 image:
-	docker pull python:3.11-slim-bullseye
+	docker pull python:3.10-slim-bullseye
 	docker build . \
 	-f docker/debian/Dockerfile \
-	--build-arg BUILDER_IMAGE=python:3.11-slim-bullseye \
+	--build-arg BUILDER_IMAGE=python:3.10-slim-bullseye \
 	--build-arg HEPMC_VERSION=2.06.11 \
 	--build-arg FASTJET_VERSION=3.3.4 \
 	--build-arg LHAPDF_VERSION=6.5.3 \
@@ -17,10 +17,10 @@ image:
 	--compress
 
 test:
-	docker pull python:3.11-slim-bullseye
+	docker pull python:3.10-slim-bullseye
 	docker build . \
 	-f docker/debian/Dockerfile \
-	--build-arg BUILDER_IMAGE=python:3.11-slim-bullseye \
+	--build-arg BUILDER_IMAGE=python:3.10-slim-bullseye \
 	--build-arg HEPMC_VERSION=2.06.11 \
 	--build-arg FASTJET_VERSION=3.3.4 \
 	--build-arg LHAPDF_VERSION=6.5.3 \

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@ default: image
 all: image
 
 image:
-	docker pull python:3.9-slim-bullseye
+	docker pull python:3.11-slim-bullseye
 	docker build . \
 	-f docker/debian/Dockerfile \
-	--build-arg BUILDER_IMAGE=python:3.9-slim-bullseye \
+	--build-arg BUILDER_IMAGE=python:3.11-slim-bullseye \
 	--build-arg HEPMC_VERSION=2.06.11 \
 	--build-arg FASTJET_VERSION=3.3.4 \
 	--build-arg LHAPDF_VERSION=6.5.3 \
@@ -17,10 +17,10 @@ image:
 	--compress
 
 test:
-	docker pull python:3.9-slim-bullseye
+	docker pull python:3.11-slim-bullseye
 	docker build . \
 	-f docker/debian/Dockerfile \
-	--build-arg BUILDER_IMAGE=python:3.9-slim-bullseye \
+	--build-arg BUILDER_IMAGE=python:3.11-slim-bullseye \
 	--build-arg HEPMC_VERSION=2.06.11 \
 	--build-arg FASTJET_VERSION=3.3.4 \
 	--build-arg LHAPDF_VERSION=6.5.3 \

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Docker image for Python 3 compliant [MadGraph5_aMC@NLO](https://launchpad.net/mg
 The Docker image contains:
 
 * [MadGraph5_aMC@NLO](https://launchpad.net/mg5amcnlo) `v3.5.0`
-* Python 3.9
+* Python 3.11 (3.9 CentOS)
 * [HepMC2](http://hepmc.web.cern.ch/hepmc/) `v2.06.11`
 * [LHAPDF](https://lhapdf.hepforge.org/) `v6.5.3`
 * [FastJet](http://fastjet.fr/) `v3.3.4`

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Docker image for Python 3 compliant [MadGraph5_aMC@NLO](https://launchpad.net/mg
 The Docker image contains:
 
 * [MadGraph5_aMC@NLO](https://launchpad.net/mg5amcnlo) `v3.5.0`
-* Python 3.11 (3.9 CentOS)
+* Python 3.10 (3.9 CentOS)
 * [HepMC2](http://hepmc.web.cern.ch/hepmc/) `v2.06.11`
 * [LHAPDF](https://lhapdf.hepforge.org/) `v6.5.3`
 * [FastJet](http://fastjet.fr/) `v3.3.4`

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILDER_IMAGE=python:3.11-slim-bullseye
+ARG BUILDER_IMAGE=python:3.10-slim-bullseye
 FROM ${BUILDER_IMAGE} as base
 
 FROM base as builder

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILDER_IMAGE=python:3.9-slim-bullseye
+ARG BUILDER_IMAGE=python:3.11-slim-bullseye
 FROM ${BUILDER_IMAGE} as base
 
 FROM base as builder


### PR DESCRIPTION
* Update base image to python:3.10-slim-bullseye for Debian build.