### PR TITLE
fix: Remove MG5_aMC directory from PYTHONPATH

### DIFF
--- a/.github/workflows/docker-centos.yml
+++ b/.github/workflows/docker-centos.yml
@@ -113,6 +113,13 @@ jobs:
           scailfin/madgraph5-amc-nlo-centos:sha-${GITHUB_SHA::8}
           "cp -r ${PWD}/tests .; cd tests; bash tests.sh"
 
+      - name: Test madevent has valid root_path
+        run: >-
+          docker run --rm
+          -v $PWD:$PWD
+          scailfin/madgraph5-amc-nlo-centos:sha-${GITHUB_SHA::8}
+          "cp -r ${PWD}/tests .; cd tests; mg5_aMC test_root_path.mg5; ./bhabha/bin/madevent launch -f"
+
       - name: Check NLO process has dependencies
         run: >-
           docker run --rm

--- a/.github/workflows/docker-centos.yml
+++ b/.github/workflows/docker-centos.yml
@@ -118,7 +118,7 @@ jobs:
           docker run --rm
           -v $PWD:$PWD
           scailfin/madgraph5-amc-nlo-centos:sha-${GITHUB_SHA::8}
-          "cp -r ${PWD}/tests .; cd tests; mg5_aMC test_root_path.mg5; ./bhabha/bin/madevent launch -f"
+          "cp -r ${PWD}/tests .; cd tests; bash test_root_path.sh"
 
       - name: Check NLO process has dependencies
         run: >-

--- a/.github/workflows/docker-debian.yml
+++ b/.github/workflows/docker-debian.yml
@@ -118,7 +118,7 @@ jobs:
           docker run --rm
           -v $PWD:$PWD
           scailfin/madgraph5-amc-nlo:sha-${GITHUB_SHA::8}
-          "cp -r ${PWD}/tests .; cd tests; mg5_aMC test_root_path.mg5; ./bhabha/bin/madevent launch -f"
+          "cp -r ${PWD}/tests .; cd tests; bash test_root_path.sh"
 
       - name: Check NLO process has dependencies
         run: >-

--- a/.github/workflows/docker-debian.yml
+++ b/.github/workflows/docker-debian.yml
@@ -113,6 +113,13 @@ jobs:
           scailfin/madgraph5-amc-nlo:sha-${GITHUB_SHA::8}
           "cp -r ${PWD}/tests .; cd tests; bash tests.sh"
 
+      - name: Test madevent has valid root_path
+        run: >-
+          docker run --rm
+          -v $PWD:$PWD
+          scailfin/madgraph5-amc-nlo:sha-${GITHUB_SHA::8}
+          "cp -r ${PWD}/tests .; cd tests; mg5_aMC test_root_path.mg5; ./bhabha/bin/madevent launch -f"
+
       - name: Check NLO process has dependencies
         run: >-
           docker run --rm

--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -226,7 +226,7 @@ COPY --from=builder --chown=moby /usr/local/venv /usr/local/venv/
 ENV LC_ALL=en_US.utf8
 ENV LANG=en_US.utf8
 
-ENV PYTHONPATH=/usr/local/venv/MG5_aMC:/usr/local/venv/lib:${PYTHONPATH}
+ENV PYTHONPATH=/usr/local/venv/lib:${PYTHONPATH}
 ENV LD_LIBRARY_PATH=/usr/local/venv/lib:$LD_LIBRARY_PATH
 ENV PATH=${HOME}/.local/bin:$PATH
 ENV PATH=/usr/local/venv/MG5_aMC/bin:$PATH

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get -qq -y update && \
     python -m pip list && \
     printf '\nexport PATH=/usr/local/venv/bin:"${PATH}"\n' >> /root/.bashrc
 
-ENV PYTHONPATH=/usr/local/venv/lib:/usr/local/venv/MG5_aMC:$PYTHONPATH
+ENV PYTHONPATH=/usr/local/venv/lib:$PYTHONPATH
 ENV LD_LIBRARY_PATH=/usr/local/venv/lib:$LD_LIBRARY_PATH
 
 # Install HepMC
@@ -226,7 +226,7 @@ ENV LANG=C.UTF-8
 
 ENV PATH=${HOME}/.local/bin:/usr/local/venv/bin:"${PATH}"
 ENV PATH=/usr/local/venv/MG5_aMC/bin:$PATH
-ENV PYTHONPATH=/usr/local/venv/lib:/usr/local/venv/MG5_aMC:$PYTHONPATH
+ENV PYTHONPATH=/usr/local/venv/lib:$PYTHONPATH
 ENV LD_LIBRARY_PATH=/usr/local/venv/lib:$LD_LIBRARY_PATH
 
 # TODO: Install NLO dependencies independently for greater control

--- a/tests/bhabha_scattering.mg5
+++ b/tests/bhabha_scattering.mg5
@@ -1,0 +1,2 @@
+generate e+ e- > e+ e-
+output bhabha

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,9 +1,3 @@
-def test_import_madgraph():
-    import madgraph
-
-    assert madgraph
-
-
 def test_import_lhapdf():
     import lhapdf
 

--- a/tests/test_root_path.mg5
+++ b/tests/test_root_path.mg5
@@ -1,3 +1,0 @@
-# c.f. https://github.com/scailfin/MadGraph5_aMC-NLO/pull/72
-generate e+ e- > e+ e-
-output bhabha

--- a/tests/test_root_path.mg5
+++ b/tests/test_root_path.mg5
@@ -1,0 +1,3 @@
+# c.f. https://github.com/scailfin/MadGraph5_aMC-NLO/pull/72
+generate e+ e- > e+ e-
+output bhabha

--- a/tests/test_root_path.sh
+++ b/tests/test_root_path.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# c.f. https://github.com/scailfin/MadGraph5_aMC-NLO/pull/72
+
+set -e
+set -u
+set -o pipefail
+
+if [ -d bhabha ]; then
+	rm -r bhabha
+fi
+
+if [ -f py.py ]; then
+	rm py.py
+fi
+
+mg5_aMC bhabha_scattering.mg5
+./bhabha/bin/madevent launch -f


### PR DESCRIPTION
* This is apparently needed to avoid conflicts with how MadGraph determiens the root_path.
   - c.f. https://bugs.launchpad.net/mg5amcnlo/+bug/2025061
* Add tests/test_root_path.sh to ensure that the root_path is valid.